### PR TITLE
added cjk ideograph images

### DIFF
--- a/data/images.json
+++ b/data/images.json
@@ -2962,9 +2962,15 @@
         "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
         "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
     ],
-    "u7533": [],
+    "u7533": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
     "u7981": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99"
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
     ],
     "u7a7a": [
         "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",

--- a/data/images.json
+++ b/data/images.json
@@ -2922,17 +2922,55 @@
         "http://digitalcollections.nypl.org/items/510d47e3-b6cf-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e2-9f90-a3d9-e040-e00a18064a99"
     ],
-    "u5272": [],
-    "u5408": [],
-    "u55b6": [],
-    "u6307": [],
-    "u6708": [],
-    "u6709": [],
-    "u6e80": [],
-    "u7121": [],
+    "u5272": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u5408": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u55b6": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u6307": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u6708": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u6709": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u6e80": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "u7121": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
     "u7533": [],
-    "u7981": [],
-    "u7a7a": [],
+    "u7981": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99"
+    ],
+    "u7a7a": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
     "uk": [],
     "umbrella":[
         "http://digitalcollections.nypl.org/items/510d47e1-263a-a3d9-e040-e00a18064a99",


### PR DESCRIPTION
for: 🈚🈯🈲🈳🈴🈵🈶🈷🈸🈹🈺

to:
http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99
http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0
http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99
