### PR TITLE
Improve how emojis are identified

### DIFF
--- a/data/images.json
+++ b/data/images.json
@@ -1,1314 +1,225 @@
 {
-    "100":[
-        "http://digitalcollections.nypl.org/items/510d47e2-416c-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-f32a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-89b6-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/a87f2350-b9e7-0131-4b72-58d385a7bbd0"
+    "#️⃣": [],
+    "*⃣": [],
+    "0️⃣": [],
+    "1️⃣": [],
+    "2️⃣": [],
+    "3️⃣": [],
+    "4️⃣": [],
+    "5️⃣": [],
+    "6️⃣": [],
+    "7️⃣": [],
+    "8️⃣": [],
+    "9️⃣": [],
+    "©️": [
+        "http://digitalcollections.nypl.org/items/510d47db-9017-a3d9-e040-e00a18064a99"
     ],
-    "1234": [],
-    "+1": [
-        "http://digitalcollections.nypl.org/items/b31f5d33-7f5a-17da-e040-e00a18062482",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-bad8-d471-e040-e00a180654d7"
+    "®️": [
+        "http://digitalcollections.nypl.org/items/510d47e0-f1fb-a3d9-e040-e00a18064a99"
     ],
-    "-1": [],
-    "8ball":[
-        "http://digitalcollections.nypl.org/items/510d47de-7680-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47de-75ba-a3d9-e040-e00a18064a99"
+    "‼️": [
+        "http://digitalcollections.nypl.org/items/cac75740-9311-0130-4b0e-58d385a7b928"
     ],
-    "a":[
-        "http://digitalcollections.nypl.org/items/6b26eaac-2b9a-1da7-e040-e00a18062258"
+    "⁉️": [],
+    "™️": [],
+    "ℹ️": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-7bf1-d471-e040-e00a180654d7"
     ],
-    "ab": [],
-    "abc":[
-        "http://digitalcollections.nypl.org/items/b0d65bdd-789d-7d0a-e040-e00a18065084"
+    "↔️": [],
+    "↕️": [],
+    "↖️": [
+        "http://digitalcollections.nypl.org/items/510d47e0-e6e1-a3d9-e040-e00a18064a99"
     ],
-    "abcd": [],
-    "accept": [],
-    "admission_tickets":[
-        "http://digitalcollections.nypl.org/items/8fabffd8-1b8e-7d20-e040-e00a180638f4",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-1f56-d471-e040-e00a180654d7"
+    "↗️": [
+        "http://digitalcollections.nypl.org/items/510d47db-da91-a3d9-e040-e00a18064a99"
     ],
-    "aerial_tramway":[
-        "http://digitalcollections.nypl.org/items/510d47e4-5a97-a3d9-e040-e00a18064a99"
+    "↘️": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ac0d-d471-e040-e00a180654d7"
     ],
-    "airplane":[
-        "http://digitalcollections.nypl.org/items/510d47d9-3de4-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-05f4-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-148c-d471-e040-e00a180654d7"
+    "↙️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-0ef0-a3d9-e040-e00a18064a99"
     ],
-    "airplane_arriving":[
-        "http://digitalcollections.nypl.org/items/78309df1-1093-23cc-e040-e00a180647e6"
+    "↩️": [],
+    "↪️": [],
+    "⌚️": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e288-d471-e040-e00a180654d7"
     ],
-    "airplane_departure":[
-        "http://digitalcollections.nypl.org/items/510d47e2-279e-a3d9-e040-e00a18064a99"
+    "⌛️": [
+        "http://digitalcollections.nypl.org/items/510d47dd-f3eb-a3d9-e040-e00a18064a99"
     ],
-    "alarm_clock":[
+    "⌨": [],
+    "⏩": [],
+    "⏪": [],
+    "⏫": [],
+    "⏬": [],
+    "⏭": [],
+    "⏮": [],
+    "⏯": [],
+    "⏰": [
         "http://digitalcollections.nypl.org/items/510d47e4-7a69-a3d9-e040-e00a18064a99"
     ],
-    "alembic":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c732-a3d9-e040-e00a18064a99"
+    "⏱": [
+        "http://digitalcollections.nypl.org/items/510d47dc-99f2-a3d9-e040-e00a18064a99"
     ],
-    "alien":[
-        "http://digitalcollections.nypl.org/items/510d47e2-9533-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-38f3-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-d565-a3d9-e040-e00a18064a99"
+    "⏲": [],
+    "⏳": [
+        "http://digitalcollections.nypl.org/items/510d47de-32f7-a3d9-e040-e00a18064a99"
     ],
-    "ambulance":[
-        "http://digitalcollections.nypl.org/items/510d47e4-25f6-a3d9-e040-e00a18064a99"
+    "⏸": [],
+    "⏹": [],
+    "⏺": [],
+    "Ⓜ️": [
+        "http://digitalcollections.nypl.org/items/510d47db-b6cd-a3d9-e040-e00a18064a99"
     ],
-    "amphora":[
-        "http://digitalcollections.nypl.org/items/510d47e4-5fb6-a3d9-e040-e00a18064a99"
+    "▪️": [],
+    "▫️": [],
+    "▶️": [],
+    "◀️": [],
+    "◻️": [],
+    "◼️": [
+        "http://digitalcollections.nypl.org/items/510d47dc-4188-a3d9-e040-e00a18064a99"
     ],
-    "anchor":[
+    "◽️": [],
+    "◾️": [
+        "http://digitalcollections.nypl.org/items/510d47dc-40eb-a3d9-e040-e00a18064a99"
+    ],
+    "☀️": [
+        "http://digitalcollections.nypl.org/items/510d47e2-1d68-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-c0c6-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-d112-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-e81f-a3d9-e040-e00a18064a99"
+    ],
+    "☁️": [
+        "http://digitalcollections.nypl.org/items/64815aa0-ea71-0131-9680-58d385a7bbd0"
+    ],
+    "☃": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c451-d471-e040-e00a180654d7"
+    ],
+    "☄": [
+        "http://digitalcollections.nypl.org/items/510d47e2-deea-a3d9-e040-e00a18064a99"
+    ],
+    "☎️": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b17d-a3d9-e040-e00a18064a99"
+    ],
+    "☑️": [
+        "http://digitalcollections.nypl.org/items/9310de90-00b1-32df-e040-e00a18065ec5"
+    ],
+    "☔️": [
+        "http://digitalcollections.nypl.org/items/510d47e1-263a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-338d-a3d9-e040-e00a18064a99"
+    ],
+    "☕️": [
+        "http://digitalcollections.nypl.org/items/a4958095-4641-074d-e040-e00a1806792c",
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-5534-f55a-e040-e00a18062565"
+    ],
+    "☘": [
+        "http://digitalcollections.nypl.org/items/510d47da-ce9e-a3d9-e040-e00a18064a99"
+    ],
+    "☝️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-1345-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/d47ffc10-dba5-0132-02b5-58d385a7b928"
+    ],
+    "☠": [
+        "http://digitalcollections.nypl.org/items/510d47db-122b-a3d9-e040-e00a18064a99"
+    ],
+    "☢": [
+        "http://digitalcollections.nypl.org/items/510d47e2-09a9-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-9419-a3d9-e040-e00a18064a99"
+    ],
+    "☣": [
+        "http://digitalcollections.nypl.org/items/510d47e0-208e-a3d9-e040-e00a18064a99"
+    ],
+    "☦": [],
+    "☪": [],
+    "☮": [],
+    "☯": [
+        "http://digitalcollections.nypl.org/items/510d47e1-0117-a3d9-e040-e00a18064a99"
+    ],
+    "☸": [],
+    "☹": [],
+    "☺️": [],
+    "♈️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7037-a3d9-e040-e00a18064a99"
+    ],
+    "♉️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-703d-a3d9-e040-e00a18064a99"
+    ],
+    "♊️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7047-a3d9-e040-e00a18064a99"
+    ],
+    "♋️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7057-a3d9-e040-e00a18064a99"
+    ],
+    "♌️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-675f-a3d9-e040-e00a18064a99"
+    ],
+    "♍️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-6761-a3d9-e040-e00a18064a99"
+    ],
+    "♎️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-676b-a3d9-e040-e00a18064a99"
+    ],
+    "♏️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-6779-a3d9-e040-e00a18064a99"
+    ],
+    "♐️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-677d-a3d9-e040-e00a18064a99"
+    ],
+    "♑️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7023-a3d9-e040-e00a18064a99"
+    ],
+    "♒️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7025-a3d9-e040-e00a18064a99"
+    ],
+    "♓️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-702d-a3d9-e040-e00a18064a99"
+    ],
+    "♠️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-2541-a3d9-e040-e00a18064a99"
+    ],
+    "♣️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-2539-a3d9-e040-e00a18064a99"
+    ],
+    "♥️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-253f-a3d9-e040-e00a18064a99"
+    ],
+    "♦️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-2545-a3d9-e040-e00a18064a99"
+    ],
+    "♨️": [
+        "http://digitalcollections.nypl.org/items/510d47da-5d28-a3d9-e040-e00a18064a99"
+    ],
+    "♻️": [],
+    "♿️": [
+        "http://digitalcollections.nypl.org/items/510d47dc-48ad-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-d0d1-a3d9-e040-e00a18064a99"
+    ],
+    "⚒": [],
+    "⚓️": [
         "http://digitalcollections.nypl.org/items/c260bdb3-9b86-4552-e040-e00a18066d81",
         "http://digitalcollections.nypl.org/items/510d47e3-406f-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47db-b632-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/ae2f51ec-bd46-66c6-e040-e00a18066cf3"
     ],
-    "angel":[
-        "http://digitalcollections.nypl.org/items/510d47e3-3e3d-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/79c4597e-dceb-8413-e040-e00a18066cd4"
-    ],
-    "anger": [
-        "http://digitalcollections.nypl.org/items/510d47e2-dc0f-a3d9-e040-e00a18064a99"    
-    ],
-    "angry":[
-        "http://digitalcollections.nypl.org/items/510d47da-9ede-a3d9-e040-e00a18064a99"
-    ],
-    "anguished": [],
-    "ant":[
-        "http://digitalcollections.nypl.org/items/510d47e1-26a2-a3d9-e040-e00a18064a99"
-    ],
-    "apple":[
-        "http://digitalcollections.nypl.org/items/510d47de-5d7f-a3d9-e040-e00a18064a99"
-    ],
-    "aquarius":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7025-a3d9-e040-e00a18064a99"
-    ],
-    "aries":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7037-a3d9-e040-e00a18064a99"
-    ],
-    "arrow_backward": [],
-    "arrow_double_down": [],
-    "arrow_double_up": [],
-    "arrow_down": [],
-    "arrow_down_small": [],
-    "arrow_forward": [],
-    "arrow_heading_down": [],
-    "arrow_heading_up": [],
-    "arrow_left":[
-        "http://digitalcollections.nypl.org/items/98e5ff00-96b3-0133-1f93-00505686d14e"
-    ],
-    "arrow_lower_left":[
-        "http://digitalcollections.nypl.org/items/510d47e3-0ef0-a3d9-e040-e00a18064a99"
-    ],
-    "arrow_lower_right":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ac0d-d471-e040-e00a180654d7"
-    ],
-    "arrow_right":[
-        "http://digitalcollections.nypl.org/items/510d47e4-37c9-a3d9-e040-e00a18064a99"
-    ],
-    "arrow_right_hook": [],
-    "arrow_up": [],
-    "arrow_up_down": [],
-    "arrow_up_small": [],
-    "arrow_upper_left":[
-        "http://digitalcollections.nypl.org/items/510d47e0-e6e1-a3d9-e040-e00a18064a99"
-    ],
-    "arrow_upper_right":[
-        "http://digitalcollections.nypl.org/items/510d47db-da91-a3d9-e040-e00a18064a99"
-    ],
-    "arrows_clockwise": [
-        "http://digitalcollections.nypl.org/items/510d47dc-836e-a3d9-e040-e00a18064a99"
-    ],
-    "arrows_counterclockwise": [
-        "http://digitalcollections.nypl.org/items/510d47e2-1dac-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-5a8c-a3d9-e040-e00a18064a99"
-    ],
-    "art":[
-        "http://digitalcollections.nypl.org/items/8f4a4f7b-fc8d-6b2c-e040-e00a180672e1"
-    ],
-    "articulated_lorry":[
-        "http://digitalcollections.nypl.org/items/510d47db-b763-a3d9-e040-e00a18064a99"
-    ],
-    "astonished":[
-        "http://digitalcollections.nypl.org/items/70833100-aafa-0132-1ad3-58d385a7bbd0"
-    ],
-    "athletic_shoe":[
-        "http://digitalcollections.nypl.org/items/510d47da-d231-a3d9-e040-e00a18064a99"
-    ],
-    "atm":[
-        "http://digitalcollections.nypl.org/items/510d47e2-eb82-a3d9-e040-e00a18064a99"
-    ],
-    "atom_symbol":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c90b-d471-e040-e00a180654d7"
-    ],
-    "b":[
-        "http://digitalcollections.nypl.org/items/6b26eaac-2b9b-1da7-e040-e00a18062258"
-    ],
-    "baby":[
-        "http://digitalcollections.nypl.org/items/510d47d9-3c9f-a3d9-e040-e00a18064a99"
-    ],
-    "baby_bottle":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-a986-d471-e040-e00a180654d7"
-    ],
-    "baby_chick":[
-        "http://digitalcollections.nypl.org/items/510d47e3-4fcd-a3d9-e040-e00a18064a99"
-    ],
-    "baby_symbol":[
-        "http://digitalcollections.nypl.org/items/510d47d9-3cd1-a3d9-e040-e00a18064a99"
-    ],
-    "back": [],
-    "badminton_racquet_and_shuttlecock": [
-        "http://digitalcollections.nypl.org/items/7d20cdeb-e419-4a73-e040-e00a18060ccc"
-    ],
-    "baggage_claim":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b7b5-a3d9-e040-e00a18064a99"
-    ],
-    "balloon":[
-        "http://digitalcollections.nypl.org/items/62a69ae1-2c09-b619-e040-e00a18062f9c"
-    ],
-    "ballot_box_with_ballot":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-80cd-d471-e040-e00a180654d7"
-    ],
-    "ballot_box_with_check":[
-        "http://digitalcollections.nypl.org/items/9310de90-00b1-32df-e040-e00a18065ec5"
-    ],
-    "bamboo":[
-        "http://digitalcollections.nypl.org/items/510d47d9-841a-a3d9-e040-e00a18064a99"
-    ],
-    "banana":[
-        "http://digitalcollections.nypl.org/items/510d47dd-f132-a3d9-e040-e00a18064a99"
-    ],
-    "bangbang":[
-        "http://digitalcollections.nypl.org/items/cac75740-9311-0130-4b0e-58d385a7b928"
-    ],
-    "bank":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-1e84-d471-e040-e00a180654d7"
-    ],
-    "bar_chart":[
-        "http://digitalcollections.nypl.org/items/e6782a70-4117-0132-82c6-58d385a7b928"
-    ],
-    "barber":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4e68-a3d9-e040-e00a18064a99"
-    ],
-    "barely_sunny":[
-        "http://digitalcollections.nypl.org/items/62ed7b00-a107-0132-c608-58d385a7b928"
-    ],
-    "baseball":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a9f9-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-c0e5-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-c101-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-c08f-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e4-0fee-a3d9-e040-e00a18064a99"
-    ],
-    "basketball":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-2840-d471-e040-e00a180654d7"
-    ],
-    "bath":[
-        "http://digitalcollections.nypl.org/items/510d47dc-4634-a3d9-e040-e00a18064a99"
-    ],
-    "bathtub":[
-        "http://digitalcollections.nypl.org/items/510d47db-ccf3-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-cccf-a3d9-e040-e00a18064a99"
-    ],
-    "battery": [],
-    "beach_with_umbrella":[
-        "http://digitalcollections.nypl.org/items/510d47df-f731-a3d9-e040-e00a18064a99"
-    ],
-    "bear":[
-        "http://digitalcollections.nypl.org/items/78309df1-0fff-23cc-e040-e00a180647e6",
-        "http://digitalcollections.nypl.org/items/510d47d9-6b06-a3d9-e040-e00a18064a99"
-    ],
-    "bed":[
-        "http://digitalcollections.nypl.org/items/510d47e4-19db-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-cb91-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/b4afdefd-4917-146a-e040-e00a180610a2"
-    ],
-    "bee":[
-        "http://digitalcollections.nypl.org/items/510d47e2-e5cc-a3d9-e040-e00a18064a99"
-    ],
-    "beer":[
-        "http://digitalcollections.nypl.org/items/510d47dd-eaad-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-37a0-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/fb711ca0-0f56-0131-af7a-58d385a7b928"
-    ],
-    "beers":[
-        "http://digitalcollections.nypl.org/items/510d47e2-e51f-a3d9-e040-e00a18064a99"
-    ],
-    "beetle": [
-        "http://digitalcollections.nypl.org/items/510d47e1-26d8-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-2b28-a3d9-e040-e00a18064a99"
-    ],
-    "beginner": [
-        "http://digitalcollections.nypl.org/items/510d47db-c934-a3d9-e040-e00a18064a99"    
-    ],
-    "bell":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a62e-a3d9-e040-e00a18064a99"
-    ],
-    "bellhop_bell":[
-        "http://digitalcollections.nypl.org/items/b0ead0eb-6644-29dc-e040-e00a18060c48",
-        "http://digitalcollections.nypl.org/items/510d47e3-f7da-a3d9-e040-e00a18064a99"
-    ],
-    "bento":[
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-5837-f55a-e040-e00a18062565"
-    ],
-    "bicyclist":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-77dc-d471-e040-e00a180654d7"
-    ],
-    "bike":[
-        "http://digitalcollections.nypl.org/items/510d47de-4b8d-a3d9-e040-e00a18064a99"
-    ],
-    "bikini":[
-        "http://digitalcollections.nypl.org/items/8d7d24d3-d51d-f0f2-e040-e00a18065a91",
-        "http://digitalcollections.nypl.org/items/510d47e2-c063-a3d9-e040-e00a18064a99"
-    ],
-    "biohazard_sign":[
-        "http://digitalcollections.nypl.org/items/510d47e0-208e-a3d9-e040-e00a18064a99"
-    ],
-    "bird":[
-        "http://digitalcollections.nypl.org/items/510d47e3-588b-a3d9-e040-e00a18064a99"
-    ],
-    "birthday":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-f5e4-d471-e040-e00a180654d7"
-    ],
-    "black_circle": [],
-    "black_circle_for_record": [],
-    "black_joker": [
-        "http://digitalcollections.nypl.org/items/510d47e2-2d36-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47df-f5d5-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-85e4-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/a491dc20-fd7a-0132-f4a4-58d385a7bbd0"
-    ],
-    "black_large_square":[
-        "http://digitalcollections.nypl.org/items/510d47dc-40eb-a3d9-e040-e00a18064a99"
-    ],
-    "black_left_pointing_double_triangle_with_vertical_bar": [],
-    "black_medium_small_square":[
-        "http://digitalcollections.nypl.org/items/510d47dc-40eb-a3d9-e040-e00a18064a99"
-    ],
-    "black_medium_square":[
-        "http://digitalcollections.nypl.org/items/510d47dc-4188-a3d9-e040-e00a18064a99"
-    ],
-    "black_nib":[
-        "http://digitalcollections.nypl.org/items/510d47db-cae7-a3d9-e040-e00a18064a99"
-    ],
-    "black_right_pointing_double_triangle_with_vertical_bar": [],
-    "black_right_pointing_triangle_with_double_vertical_bar": [],
-    "black_small_square": [],
-    "black_square_button": [
-        "http://digitalcollections.nypl.org/items/510d47da-ec7d-a3d9-e040-e00a18064a99"    
-    ],
-    "black_square_for_stop": [],
-    "blossom":[
-        "http://digitalcollections.nypl.org/items/510d47e3-358d-a3d9-e040-e00a18064a99"
-    ],
-    "blowfish":[
-        "http://digitalcollections.nypl.org/items/510d47e3-3791-a3d9-e040-e00a18064a99"
-    ],
-    "blue_book":[
-        "http://digitalcollections.nypl.org/items/510d47db-c96b-a3d9-e040-e00a18064a99"
-    ],
-    "blue_car":[
-        "http://digitalcollections.nypl.org/items/510d47da-d985-a3d9-e040-e00a18064a99"
-    ],
-    "blue_heart":[
-        "http://digitalcollections.nypl.org/items/510d47e3-64b3-a3d9-e040-e00a18064a99"
-    ],
-    "blush":[
-        "http://digitalcollections.nypl.org/items/510d47e2-f3cb-a3d9-e040-e00a18064a99"
-    ],
-    "boar":[
-        "http://digitalcollections.nypl.org/items/510d47da-9d7e-a3d9-e040-e00a18064a99"
-    ],
-    "boat":[
-        "http://digitalcollections.nypl.org/items/510d47d9-baa0-a3d9-e040-e00a18064a99"
-    ],
-    "bomb":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b6c5-a3d9-e040-e00a18064a99"
-    ],
-    "book":[
-        "http://digitalcollections.nypl.org/items/510d47da-4715-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-cefa-a3d9-e040-e00a18064a99"
-    ],
-    "bookmark":[
-        "http://digitalcollections.nypl.org/items/9eff8bbf-ca5d-c3c0-e040-e00a1806603f"
-    ],
-    "bookmark_tabs":[
-        "http://digitalcollections.nypl.org/items/510d47da-e3aa-a3d9-e040-e00a18064a99"
-    ],
-    "books":[
-        "http://digitalcollections.nypl.org/items/510d47dd-e4ca-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47df-e348-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-8245-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-eb75-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-eb79-a3d9-e040-e00a18064a99"
-    ],
-    "boom":[
-        "http://digitalcollections.nypl.org/items/510d47d9-3f2a-a3d9-e040-e00a18064a99"
-    ],
-    "boot":[
-        "http://digitalcollections.nypl.org/items/510d47e1-32d2-a3d9-e040-e00a18064a99"
-    ],
-    "bouquet":[
-        "http://digitalcollections.nypl.org/items/510d47e3-922a-a3d9-e040-e00a18064a99"
-    ],
-    "bow":[
-        "http://digitalcollections.nypl.org/items/c8526e10-2571-0132-437b-58d385a7b928"
-    ],
-    "bow_and_arrow":[
-        "http://digitalcollections.nypl.org/items/510d47e3-0ef0-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e4-0c52-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-3d37-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-0946-a3d9-e040-e00a18064a99"
-    ],
-    "bowling":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4d88-a3d9-e040-e00a18064a99"
-    ],
-    "boy":[
-        "http://digitalcollections.nypl.org/items/3266ed40-2289-0132-cf76-58d385a7bbd0"
-    ],
-    "bread":[
-        "http://digitalcollections.nypl.org/items/bb13368d-1df6-86eb-e040-e00a18066010"
-    ],
-    "bride_with_veil":[
-        "http://digitalcollections.nypl.org/items/510d47e1-07b2-a3d9-e040-e00a18064a99"
-    ],
-    "bridge_at_night":[
-        "http://digitalcollections.nypl.org/items/510d47e1-2d11-a3d9-e040-e00a18064a99"
-    ],
-    "briefcase":[
-        "http://digitalcollections.nypl.org/items/510d47e0-f018-a3d9-e040-e00a18064a99"
-    ],
-    "broken_heart":[
-        "http://digitalcollections.nypl.org/items/510d47da-708e-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47de-184a-a3d9-e040-e00a18064a99"
-    ],
-    "bug":[
-        "http://digitalcollections.nypl.org/items/510d47d9-79d0-a3d9-e040-e00a18064a99"
-    ],
-    "building_construction":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-cef1-d471-e040-e00a180654d7"
-    ],
-    "bulb":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-82b0-d471-e040-e00a180654d7"
-    ],
-    "bullettrain_front": [],
-    "bullettrain_side": [],
-    "burrito": [
-        "http://digitalcollections.nypl.org/items/510d47de-ae8b-a3d9-e040-e00a18064a99"    
-    ],
-    "bus":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-da0e-d471-e040-e00a180654d7"
-    ],
-    "busstop":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4f7c-a3d9-e040-e00a18064a99"
-    ],
-    "bust_in_silhouette":[
-        "http://digitalcollections.nypl.org/items/510d47de-0847-a3d9-e040-e00a18064a99"
-    ],
-    "busts_in_silhouette":[
-        "http://digitalcollections.nypl.org/items/510d47db-b6d2-a3d9-e040-e00a18064a99"
-    ],
-    "cactus":[
-        "http://digitalcollections.nypl.org/items/510d47d9-9d74-a3d9-e040-e00a18064a99"
-    ],
-    "cake":[
-        "http://digitalcollections.nypl.org/items/61bb8540-c759-0132-e6ba-58d385a7bbd0"
-    ],
-    "calendar": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-6d47-d471-e040-e00a180654d7"    
-    ],
-    "calling": [],
-    "camel":[
-        "http://digitalcollections.nypl.org/items/510d47e1-43ec-a3d9-e040-e00a18064a99"
-    ],
-    "camera":[
-        "http://digitalcollections.nypl.org/items/510d47e2-4778-a3d9-e040-e00a18064a99"
-    ],
-    "camera_with_flash":[
-        "http://digitalcollections.nypl.org/items/b153a2d9-9cd0-2146-e040-e00a18062823"
-    ],
-    "camping":[
-        "http://digitalcollections.nypl.org/items/510d47de-331d-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-d022-a3d9-e040-e00a18064a99"
-    ],
-    "cancer":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7057-a3d9-e040-e00a18064a99"
-    ],
-    "candle":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-d388-d471-e040-e00a180654d7"
-    ],
-    "candy":[
-        "http://digitalcollections.nypl.org/items/ccd47a10-21ce-0133-43a7-58d385a7b928"
-    ],
-    "capital_abcd":[
-        "http://digitalcollections.nypl.org/items/6b26eaac-2bae-1da7-e040-e00a18062258"
-    ],
-    "capricorn":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7023-a3d9-e040-e00a18064a99"
-    ],
-    "car":[
-        "http://digitalcollections.nypl.org/items/510d47da-b8a9-a3d9-e040-e00a18064a99"
-    ],
-    "card_file_box": [],
-    "card_index":[],
-    "card_index_dividers": [],
-    "carousel_horse":[
-        "http://digitalcollections.nypl.org/items/7b58749c-8e91-480a-e040-e00a180668d3"
-    ],
-    "cat":[
-        "http://digitalcollections.nypl.org/items/510d47de-6c14-a3d9-e040-e00a18064a99"
-    ],
-    "cat2":[
-        "http://digitalcollections.nypl.org/items/36735660-e04c-0131-c3ef-58d385a7bbd0"
-    ],
-    "cd":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-0888-d471-e040-e00a180654d7"
-    ],
-    "chains":[
-        "http://digitalcollections.nypl.org/items/510d47e1-2499-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-2444-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-fc23-a3d9-e040-e00a18064a99"
-    ],
-    "champagne":[
-        "http://digitalcollections.nypl.org/items/510d47db-3ec6-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-3be2-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-d810-a3d9-e040-e00a18064a99"
-    ],
-    "chart": [],
-    "chart_with_downwards_trend": [],
-    "chart_with_upwards_trend": [
-        "http://digitalcollections.nypl.org/items/510d47db-d7fb-a3d9-e040-e00a18064a99"
-    ],
-    "checkered_flag":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-af71-d471-e040-e00a180654d7"
-    ],
-    "cheese_wedge":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4f62-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-9d99-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/ba309cea-92f4-4288-e040-e00a18066c61"
-    ],
-    "cherries":[
-        "http://digitalcollections.nypl.org/items/510d47dd-d8d5-a3d9-e040-e00a18064a99"
-    ],
-    "cherry_blossom":[
-        "http://digitalcollections.nypl.org/items/510d47e1-cae3-a3d9-e040-e00a18064a99"
-    ],
-    "chestnut":[
-        "http://digitalcollections.nypl.org/items/510d47de-5d8d-a3d9-e040-e00a18064a99"
-    ],
-    "chicken":[
-        "http://digitalcollections.nypl.org/items/510d47e2-d4bc-a3d9-e040-e00a18064a99"
-    ],
-    "children_crossing": [],
-    "chipmunk":[
-        "http://digitalcollections.nypl.org/items/510d47e1-41c8-a3d9-e040-e00a18064a99"
-    ],
-    "chocolate_bar":[
-        "http://digitalcollections.nypl.org/items/510d47e1-20a0-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-a987-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-b510-a3d9-e040-e00a18064a99"
-    ],
-    "christmas_tree":[
-        "http://digitalcollections.nypl.org/items/510d47e3-67b9-a3d9-e040-e00a18064a99"
-    ],
-    "church":[
-        "http://digitalcollections.nypl.org/items/510d47d9-5075-a3d9-e040-e00a18064a99"
-    ],
-    "cinema":[
-        "http://digitalcollections.nypl.org/items/a15fc5c4-8411-f36d-e040-e00a18062fdc",
-        "http://digitalcollections.nypl.org/items/63abe500-00a5-0133-0a70-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/83d56b71-44fb-2a82-e040-e00a1806337f",
-        "http://digitalcollections.nypl.org/items/dd8bab80-00a4-0133-c481-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/27734160-00a5-0133-905f-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47df-f986-a3d9-e040-e00a18064a99"
-    ],
-    "circus_tent":[
-        "http://digitalcollections.nypl.org/items/b7ece31d-7f99-8808-e040-e00a18063f2c"
-    ],
-    "city_sunrise":[
-        "http://digitalcollections.nypl.org/items/510d47e2-8b0b-a3d9-e040-e00a18064a99"
-    ],
-    "city_sunset":[
-        "http://digitalcollections.nypl.org/items/510d47e2-8e15-a3d9-e040-e00a18064a99"
-    ],
-    "cityscape":[
-        "http://digitalcollections.nypl.org/items/510d47e1-4145-a3d9-e040-e00a18064a99"
-    ],
-    "cl": [],
-    "clap":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-8869-d471-e040-e00a180654d7"
-    ],
-    "clapper":[
-        "http://digitalcollections.nypl.org/items/510d47e4-786e-a3d9-e040-e00a18064a99"
-    ],
-    "classical_building":[
-        "http://digitalcollections.nypl.org/items/510d47e0-a9ee-a3d9-e040-e00a18064a99"
-    ],
-    "clipboard":[
-        "http://digitalcollections.nypl.org/items/510d47dd-9cae-a3d9-e040-e00a18064a99"
-    ],
-    "clock1":[
-        "http://digitalcollections.nypl.org/items/510d47de-3abd-a3d9-e040-e00a18064a99"
-    ],
-    "clock10":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-79d7-d471-e040-e00a180654d7"
-    ],
-    "clock1030":[
-        "http://digitalcollections.nypl.org/items/510d47de-3313-a3d9-e040-e00a18064a99"
-    ],
-    "clock11":[
-        "http://digitalcollections.nypl.org/items/510d47da-d221-a3d9-e040-e00a18064a99"
-    ],
-    "clock1130":[
-        "http://digitalcollections.nypl.org/items/510d47db-47c6-a3d9-e040-e00a18064a99"
-    ],
-    "clock12":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-26e5-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47e3-47d5-a3d9-e040-e00a18064a99"
-    ],
-    "clock1230":[
-        "http://digitalcollections.nypl.org/items/510d47dc-3ef4-a3d9-e040-e00a18064a99"
-    ],
-    "clock130":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-9e6c-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47de-8192-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-897d-a3d9-e040-e00a18064a99"
-    ],
-    "clock2":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7762-a3d9-e040-e00a18064a99"
-    ],
-    "clock230":[
-        "http://digitalcollections.nypl.org/items/510d47de-3317-a3d9-e040-e00a18064a99"
-    ],
-    "clock3":[
-        "http://digitalcollections.nypl.org/items/ebc895c0-f368-0132-6737-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47de-3319-a3d9-e040-e00a18064a99"
-    ],
-    "clock330":[
-        "http://digitalcollections.nypl.org/items/510d47de-32f5-a3d9-e040-e00a18064a99"
-    ],
-    "clock4":[
-        "http://digitalcollections.nypl.org/items/510d47e1-a724-a3d9-e040-e00a18064a99"
-    ],
-    "clock430":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7aa7-a3d9-e040-e00a18064a99"
-    ],
-    "clock5":[
-        "http://digitalcollections.nypl.org/items/510d47db-875b-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47de-8190-a3d9-e040-e00a18064a99"
-    ],
-    "clock530":[
-        "http://digitalcollections.nypl.org/items/510d47dc-3a56-a3d9-e040-e00a18064a99"
-    ],
-    "clock6": [],
-    "clock630":[
-        "http://digitalcollections.nypl.org/items/510d47dd-a65b-a3d9-e040-e00a18064a99"
-    ],
-    "clock7":[
-        "http://digitalcollections.nypl.org/items/510d47de-818f-a3d9-e040-e00a18064a99"
-    ],
-    "clock730": [],
-    "clock8":[
-        "http://digitalcollections.nypl.org/items/510d47e0-ccd5-a3d9-e040-e00a18064a99"
-    ],
-    "clock830":[
-        "http://digitalcollections.nypl.org/items/510d47e1-25a1-a3d9-e040-e00a18064a99"
-    ],
-    "clock9":[
-        "http://digitalcollections.nypl.org/items/510d47e1-160c-a3d9-e040-e00a18064a99"
-    ],
-    "clock930":[
-        "http://digitalcollections.nypl.org/items/510d47db-a48d-a3d9-e040-e00a18064a99"
-    ],
-    "closed_book":[
-        "http://digitalcollections.nypl.org/items/510d47dc-965b-a3d9-e040-e00a18064a99"
-    ],
-    "closed_lock_with_key":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c7c5-a3d9-e040-e00a18064a99"
-    ],
-    "closed_umbrella":[
-        "http://digitalcollections.nypl.org/items/510d47db-1b31-a3d9-e040-e00a18064a99"
-    ],
-    "cloud":[
-        "http://digitalcollections.nypl.org/items/64815aa0-ea71-0131-9680-58d385a7bbd0"
-    ],
-    "clubs":[
-        "http://digitalcollections.nypl.org/items/510d47e3-2539-a3d9-e040-e00a18064a99"
-    ],
-    "cn": [],
-    "cocktail":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-0b29-d471-e040-e00a180654d7"
-    ],
-    "coffee":[
-        "http://digitalcollections.nypl.org/items/a4958095-4641-074d-e040-e00a1806792c",
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-5534-f55a-e040-e00a18062565"
-    ],
-    "coffin":[
-        "http://digitalcollections.nypl.org/items/acfeeb2d-78cf-4ce7-e040-e00a180644aa"
-    ],
-    "cold_sweat":[
-        "http://digitalcollections.nypl.org/items/510d47e2-ffca-a3d9-e040-e00a18064a99"
-    ],
-    "collision": [],
-    "comet":[
-        "http://digitalcollections.nypl.org/items/510d47e2-deea-a3d9-e040-e00a18064a99"
-    ],
-    "compression":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4ea7-a3d9-e040-e00a18064a99"
-    ],
-    "computer": [],
-    "confetti_ball":[
-        "http://digitalcollections.nypl.org/items/510d47e2-d1aa-a3d9-e040-e00a18064a99"
-    ],
-    "confounded":[
-        "http://digitalcollections.nypl.org/items/f85e0e90-f8d3-0132-bd5f-58d385a7b928"
-    ],
-    "confused":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-756b-3443-e040-e00a18067692"
-    ],
-    "congratulations": [],
-    "construction": [],
-    "construction_worker":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a8fe-a3d9-e040-e00a18064a99"
-    ],
-    "control_knobs":[
-        "http://digitalcollections.nypl.org/items/510d47de-5f5b-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-e908-a3d9-e040-e00a18064a99"
-    ],
-    "convenience_store":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c03c-a3d9-e040-e00a18064a99"
-    ],
-    "cookie":[
-        "http://digitalcollections.nypl.org/items/510d47de-3ae1-a3d9-e040-e00a18064a99"
-    ],
-    "cool":[
-        "http://digitalcollections.nypl.org/items/39427570-089e-0133-a70f-58d385a7b928"
-    ],
-    "cop":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-d81b-d471-e040-e00a180654d7"
-    ],
-    "copyright":[
-        "http://digitalcollections.nypl.org/items/510d47db-9017-a3d9-e040-e00a18064a99"
-    ],
-    "corn":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6477-a3d9-e040-e00a18064a99"
-    ],
-    "couch_and_lamp":[
-        "http://digitalcollections.nypl.org/items/510d47e2-cb71-a3d9-e040-e00a18064a99"
-    ],
-    "couple":[
-        "http://digitalcollections.nypl.org/items/286a7aa0-024b-0133-d968-58d385a7bbd0"
-    ],
-    "couple_with_heart":[
-        "http://digitalcollections.nypl.org/items/510d47e3-fc97-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-6499-a3d9-e040-e00a18064a99"
-    ],
-    "couplekiss":[
-        "http://digitalcollections.nypl.org/items/510d47e2-e5f6-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-9fef-a3d9-e040-e00a18064a99"
-    ],
-    "cow":[
-        "http://digitalcollections.nypl.org/items/b4238231-43b4-56ba-e040-e00a18066127"
-    ],
-    "cow2":[
-        "http://digitalcollections.nypl.org/items/510d47e1-418d-a3d9-e040-e00a18064a99"
-    ],
-    "crab":[
-        "http://digitalcollections.nypl.org/items/510d47e4-0fd6-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e4-0fe3-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/ac4b45d0-f810-0132-883f-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47da-66de-a3d9-e040-e00a18064a99"
-    ],
-    "credit_card": [],
-    "crescent_moon":[
-        "http://digitalcollections.nypl.org/items/510d47df-f210-a3d9-e040-e00a18064a99"
-    ],
-    "cricket_bat_and_ball":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c1cd-a3d9-e040-e00a18064a99"
-    ],
-    "crocodile":[
-        "http://digitalcollections.nypl.org/items/510d47da-9e3a-a3d9-e040-e00a18064a99"
-    ],
-    "crossed_flags":[
-        "http://digitalcollections.nypl.org/items/510d47da-d1d4-a3d9-e040-e00a18064a99"
-    ],
-    "crossed_swords":[
+    "⚔": [
         "http://digitalcollections.nypl.org/items/510d47e2-f3b5-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/b00d2570-07cd-0133-831b-58d385a7b928"
     ],
-    "crown":[
-        "http://digitalcollections.nypl.org/items/510d47de-5aa3-a3d9-e040-e00a18064a99"
+    "⚖": [
+        "http://digitalcollections.nypl.org/items/510d47dd-d3af-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/191f18f0-1696-0132-8346-58d385a7b928"
     ],
-    "cry":[
-        "http://digitalcollections.nypl.org/items/510d47da-44d8-a3d9-e040-e00a18064a99"
+    "⚗": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c732-a3d9-e040-e00a18064a99"
     ],
-    "crying_cat_face":[
-        "http://digitalcollections.nypl.org/items/510d47de-ea0d-a3d9-e040-e00a18064a99"
+    "⚙": [
+        "http://digitalcollections.nypl.org/items/510d47e4-41f1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e4-7b01-a3d9-e040-e00a18064a99"
     ],
-    "crystal_ball":[
-        "http://digitalcollections.nypl.org/items/510d47e1-3cc5-a3d9-e040-e00a18064a99"
+    "⚛": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c90b-d471-e040-e00a180654d7"
     ],
-    "cupid":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6493-a3d9-e040-e00a18064a99"
-    ],
-    "curly_loop":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7b29-a3d9-e040-e00a18064a99"
-    ],
-    "currency_exchange": [],
-    "curry": [
-        "http://digitalcollections.nypl.org/items/510d47db-4f05-a3d9-e040-e00a18064a99"    
-    ],
-    "custard":[
-        "http://digitalcollections.nypl.org/items/510d47de-3aed-a3d9-e040-e00a18064a99"
-    ],
-    "customs":[
-        "http://digitalcollections.nypl.org/items/510d47d9-974f-a3d9-e040-e00a18064a99"
-    ],
-    "cyclone":[
-        "http://digitalcollections.nypl.org/items/510d47d9-aa8a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-5225-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-c2f9-a3d9-e040-e00a18064a99"
-    ],
-    "dagger_knife":[
-        "http://digitalcollections.nypl.org/items/510d47e3-8fe7-a3d9-e040-e00a18064a99"
-    ],
-    "dancer":[
-        "http://digitalcollections.nypl.org/items/67f427f0-ba01-0132-11ed-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47de-178a-a3d9-e040-e00a18064a99"
-    ],
-    "dancers":[
-        "http://digitalcollections.nypl.org/items/c3fd2980-5be0-0133-0793-00505686a51c",
-        "http://digitalcollections.nypl.org/items/8d028a2d-162d-adb4-e040-e00a18063458",
-        "http://digitalcollections.nypl.org/items/8df28a48-1bfb-56f0-e040-e00a1806391d",
-        "http://digitalcollections.nypl.org/items/1fd0d8c0-a895-0131-d091-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/afd620b0-d82f-2b70-e040-e00a180642e8"
-    ],
-    "dango": [],
-    "dark_sunglasses":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-0cda-d471-e040-e00a180654d7"
-    ],
-    "dart":[
-        "http://digitalcollections.nypl.org/items/510d47e3-afa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-d198-a3d9-e040-e00a18064a99"
-    ],
-    "dash":[
-        "http://digitalcollections.nypl.org/items/510d47e2-18a6-a3d9-e040-e00a18064a99"
-    ],
-    "date":[
-        "http://digitalcollections.nypl.org/items/510d47de-66df-a3d9-e040-e00a18064a99"
-    ],
-    "de": [],
-    "deciduous_tree":[
-        "http://digitalcollections.nypl.org/items/510d47de-5f93-a3d9-e040-e00a18064a99"
-    ],
-    "department_store":[
-        "http://digitalcollections.nypl.org/items/510d47e0-d334-a3d9-e040-e00a18064a99"
-    ],
-    "derelict_house_building":[
-        "http://digitalcollections.nypl.org/items/b4afdefd-4988-146a-e040-e00a180610a2"
-    ],
-    "desert":[
-        "http://digitalcollections.nypl.org/items/510d47da-35ae-a3d9-e040-e00a18064a99"
-    ],
-    "desert_island":[
-        "http://digitalcollections.nypl.org/items/510d47d9-9ae5-a3d9-e040-e00a18064a99"
-    ],
-    "desktop_computer": [],
-    "diamond_shape_with_a_dot_inside": [],
-    "diamonds":[
-        "http://digitalcollections.nypl.org/items/510d47e3-2545-a3d9-e040-e00a18064a99"
-    ],
-    "disappointed":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-757f-3443-e040-e00a18067692"
-    ],
-    "disappointed_relieved":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-7591-3443-e040-e00a18067692"
-    ],
-    "dizzy":[
-        "http://digitalcollections.nypl.org/items/510d47e2-1d1c-a3d9-e040-e00a18064a99"
-    ],
-    "dizzy_face":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-75d3-3443-e040-e00a18067692"
-    ],
-    "do_not_litter":[
-        "http://digitalcollections.nypl.org/items/b4afdefd-4c53-146a-e040-e00a180610a2"
-    ],
-    "dog":[
-        "http://digitalcollections.nypl.org/items/510d47e1-43b1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-05a8-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-c980-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-20e7-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5da15340-964a-0130-1b3f-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/53460140-e04c-0131-32c5-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47db-c4d3-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/c3903dcb-c932-6201-e040-e00a180642e6",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c083-d471-e040-e00a180654d7"
-    ],
-    "dog2":[
-        "http://digitalcollections.nypl.org/items/510d47dd-bd98-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-9277-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-3c8a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/b153a2d9-9cbc-2146-e040-e00a18062823"
-    ],
-    "dollar":[
-        "http://digitalcollections.nypl.org/items/510d47e3-5334-a3d9-e040-e00a18064a99"
-    ],
-    "dolls":[
-        "http://digitalcollections.nypl.org/items/c261ef12-e4d4-3577-e040-e00a18067776"
-    ],
-    "dolphin":[
-        "http://digitalcollections.nypl.org/items/510d47e3-2b0c-a3d9-e040-e00a18064a99"
-    ],
-    "door":[
-        "http://digitalcollections.nypl.org/items/af816b78-c7c5-c09e-e040-e00a18062945",
-        "http://digitalcollections.nypl.org/items/aea7cced-6f65-982c-e040-e00a1806318e",
-        "http://digitalcollections.nypl.org/items/aea7cced-6f14-982c-e040-e00a1806318e",
-        "http://digitalcollections.nypl.org/items/aea7cced-6f29-982c-e040-e00a1806318e",
-        "http://digitalcollections.nypl.org/items/aea7cced-7137-982c-e040-e00a1806318e"
-    ],
-    "double_vertical_bar": [],
-    "doughnut":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-801e-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-2890-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/ba355981-5685-de30-e040-e00a1806351c"
-    ],
-    "dove_of_peace":[
-        "http://digitalcollections.nypl.org/items/510d47e2-e61a-a3d9-e040-e00a18064a99"
-    ],
-    "dragon":[
-        "http://digitalcollections.nypl.org/items/510d47db-58dc-a3d9-e040-e00a18064a99"
-    ],
-    "dragon_face":[
-        "http://digitalcollections.nypl.org/items/510d47e3-75f4-a3d9-e040-e00a18064a99"
-    ],
-    "dress":[
-        "http://digitalcollections.nypl.org/items/8af99501-8288-161c-e040-e00a18064530"
-    ],
-    "dromedary_camel":[
-        "http://digitalcollections.nypl.org/items/510d47d9-52b6-a3d9-e040-e00a18064a99"
-    ],
-    "droplet": [],
-    "dvd": [],
-    "e-mail": [],
-    "ear":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7291-a3d9-e040-e00a18064a99"
-    ],
-    "ear_of_rice":[
-        "http://digitalcollections.nypl.org/items/510d47e0-11aa-a3d9-e040-e00a18064a99"
-    ],
-    "earth_africa":[
-        "http://digitalcollections.nypl.org/items/b631ab46-2320-5c16-e040-e00a18064aaf"
-    ],
-    "earth_americas":[
-        "http://digitalcollections.nypl.org/items/b631fc9e-4ea3-7f06-e040-e00a18064f89"
-    ],
-    "earth_asia":[
-        "http://digitalcollections.nypl.org/items/b631aa51-b8a6-847c-e040-e00a18064b4a"
-    ],
-    "egg":[
-        "http://digitalcollections.nypl.org/items/510d47de-3b0b-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47de-3881-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-29d8-d471-e040-e00a180654d7"
-    ],
-    "eggplant":[
-        "http://digitalcollections.nypl.org/items/510d47e2-f5a8-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dc-7c97-a3d9-e040-e00a18064a99"
-    ],
-    "eight": [],
-    "eight_pointed_black_star":[
-        "http://digitalcollections.nypl.org/items/510d47dd-e81f-a3d9-e040-e00a18064a99"
-    ],
-    "eight_spoked_asterisk":[
-        "http://digitalcollections.nypl.org/items/510d47e1-1658-a3d9-e040-e00a18064a99"
-    ],
-    "electric_plug": [],
-    "elephant":[
-        "http://digitalcollections.nypl.org/items/510d47e1-42d8-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-bbec-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-24d6-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-6d38-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-99dc-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-9ac3-a3d9-e040-e00a18064a99"
-    ],
-    "email":[
-        "http://digitalcollections.nypl.org/items/510d47df-f38a-a3d9-e040-e00a18064a99"
-    ],
-    "end": [],
-    "envelope": [],
-    "envelope_with_arrow":[
-        "http://digitalcollections.nypl.org/items/510d47e3-565c-a3d9-e040-e00a18064a99"
-    ],
-    "es": [],
-    "euro": [],
-    "european_castle":[
-        "http://digitalcollections.nypl.org/items/510d47e2-edd6-a3d9-e040-e00a18064a99"
-    ],
-    "european_post_office": [],
-    "evergreen_tree":[
-        "http://digitalcollections.nypl.org/items/510d47de-5f87-a3d9-e040-e00a18064a99"
-    ],
-    "exclamation": [],
-    "expressionless": [
-        "http://digitalcollections.nypl.org/items/aa16d2ae-7561-3443-e040-e00a18067692"    
-    ],
-    "eye":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-6c2e-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-27b1-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ebf2-d471-e040-e00a180654d7"
-    ],
-    "eyeglasses":[
-        "http://digitalcollections.nypl.org/items/510d47d9-be15-a3d9-e040-e00a18064a99"
-    ],
-    "eyes":[
-        "http://digitalcollections.nypl.org/items/23e7a6b0-2fd0-0133-6064-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/99bdb5d2-c87c-c064-e040-e00a180650d2"
-    ],
-    "face_with_head_bandage":[
-        "http://digitalcollections.nypl.org/items/510d47e3-0218-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-001c-a3d9-e040-e00a18064a99"
-    ],
-    "face_with_rolling_eyes":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-75ed-3443-e040-e00a18067692"
-    ],
-    "face_with_thermometer": [],
-    "facepunch":[
-        "http://digitalcollections.nypl.org/items/510d47d9-bd29-a3d9-e040-e00a18064a99"
-    ],
-    "factory":[
-        "http://digitalcollections.nypl.org/items/510d47de-075e-a3d9-e040-e00a18064a99"
-    ],
-    "fallen_leaf":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7a6f-a3d9-e040-e00a18064a99"
-    ],
-    "family": [],
-    "fast_forward": [],
-    "fax": [],
-    "fearful":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-75d7-3443-e040-e00a18067692"
-    ],
-    "feet":[
-        "http://digitalcollections.nypl.org/items/510d47e1-3255-a3d9-e040-e00a18064a99"
-    ],
-    "ferris_wheel":[
-        "http://digitalcollections.nypl.org/items/510d47dd-f4cc-a3d9-e040-e00a18064a99"
-    ],
-    "ferry":[
-        "http://digitalcollections.nypl.org/items/510d47d9-cbba-a3d9-e040-e00a18064a99"
-    ],
-    "field_hockey_stick_and_ball":[
-        "http://digitalcollections.nypl.org/items/510d47da-6ab5-a3d9-e040-e00a18064a99"
-    ],
-    "file_cabinet":[
-        "http://digitalcollections.nypl.org/items/510d47dd-eb5f-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47df-ac6b-a3d9-e040-e00a18064a99"
-    ],
-    "file_folder":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c9d1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-c757-a3d9-e040-e00a18064a99"
-    ],
-    "film_frames":[
-        "http://digitalcollections.nypl.org/items/44a6a410-ccdd-0132-8a1f-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/a7485830-ccdd-0132-5a26-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/6d5d1960-ccdd-0132-4dbd-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/f96a3440-ccdd-0132-4545-58d385a7bbd0"
-    ],
-    "film_projector":[
-        "http://digitalcollections.nypl.org/items/510d47da-92cd-a3d9-e040-e00a18064a99"
-    ],
-    "fire":[
-        "http://digitalcollections.nypl.org/items/510d47e2-fd9a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-e537-a3d9-e040-e00a18064a99"
-    ],
-    "fire_engine":[
-        "http://digitalcollections.nypl.org/items/510d47db-b75f-a3d9-e040-e00a18064a99"
-    ],
-    "fireworks":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-aaa1-d471-e040-e00a180654d7"
-    ],
-    "first_quarter_moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
-    ],
-    "first_quarter_moon_with_face":[
-        "http://digitalcollections.nypl.org/items/96c1c508-1f08-dfa7-e040-e00a1806799d"
-    ],
-    "fish":[
-        "http://digitalcollections.nypl.org/items/510d47da-66c7-a3d9-e040-e00a18064a99"
-    ],
-    "fish_cake": [],
-    "fishing_pole_and_fish":[
-        "http://digitalcollections.nypl.org/items/510d47da-991c-a3d9-e040-e00a18064a99"
-    ],
-    "fist":[
-        "http://digitalcollections.nypl.org/items/510d47e3-cbcd-a3d9-e040-e00a18064a99"
-    ],
-    "five": [],
-    "flag-ac": [],
-    "flag-ad": [],
-    "flag-ae": [],
-    "flag-af": [],
-    "flag-ag": [],
-    "flag-ai": [],
-    "flag-al": [],
-    "flag-am": [],
-    "flag-ao": [],
-    "flag-aq": [],
-    "flag-ar": [],
-    "flag-as": [],
-    "flag-at": [],
-    "flag-au": [],
-    "flag-aw": [],
-    "flag-ax": [],
-    "flag-az": [],
-    "flag-ba": [],
-    "flag-bb": [],
-    "flag-bd": [],
-    "flag-be": [],
-    "flag-bf": [],
-    "flag-bg": [],
-    "flag-bh": [],
-    "flag-bi": [],
-    "flag-bj": [],
-    "flag-bl": [],
-    "flag-bm": [],
-    "flag-bn": [],
-    "flag-bo": [],
-    "flag-bq": [],
-    "flag-br": [],
-    "flag-bs": [],
-    "flag-bt": [],
-    "flag-bv": [],
-    "flag-bw": [],
-    "flag-by": [],
-    "flag-bz": [],
-    "flag-ca": [],
-    "flag-cc": [],
-    "flag-cd": [],
-    "flag-cf": [],
-    "flag-cg": [],
-    "flag-ch": [],
-    "flag-ci": [],
-    "flag-ck": [],
-    "flag-cl": [],
-    "flag-cm": [],
-    "flag-cn": [],
-    "flag-co": [],
-    "flag-cp": [],
-    "flag-cr": [],
-    "flag-cu": [],
-    "flag-cv": [],
-    "flag-cw": [],
-    "flag-cx": [],
-    "flag-cy": [],
-    "flag-cz": [],
-    "flag-de": [],
-    "flag-dg": [],
-    "flag-dj": [],
-    "flag-dk": [],
-    "flag-dm": [],
-    "flag-do": [],
-    "flag-dz": [],
-    "flag-ea": [],
-    "flag-ec": [],
-    "flag-ee": [],
-    "flag-eg": [],
-    "flag-eh": [],
-    "flag-er": [],
-    "flag-es": [],
-    "flag-et": [],
-    "flag-eu": [],
-    "flag-fi": [],
-    "flag-fj": [],
-    "flag-fk": [],
-    "flag-fm": [],
-    "flag-fo": [],
-    "flag-fr": [],
-    "flag-ga": [],
-    "flag-gb": [],
-    "flag-gd": [],
-    "flag-ge": [],
-    "flag-gf": [],
-    "flag-gg": [],
-    "flag-gh": [],
-    "flag-gi": [],
-    "flag-gl": [],
-    "flag-gm": [],
-    "flag-gn": [],
-    "flag-gp": [],
-    "flag-gq": [],
-    "flag-gr": [],
-    "flag-gs": [],
-    "flag-gt": [],
-    "flag-gu": [],
-    "flag-gw": [],
-    "flag-gy": [],
-    "flag-hk": [],
-    "flag-hm": [],
-    "flag-hn": [],
-    "flag-hr": [],
-    "flag-ht": [],
-    "flag-hu": [],
-    "flag-ic": [],
-    "flag-id": [],
-    "flag-ie": [],
-    "flag-il": [],
-    "flag-im": [],
-    "flag-in": [],
-    "flag-io": [],
-    "flag-iq": [],
-    "flag-ir": [],
-    "flag-is": [],
-    "flag-it": [],
-    "flag-je": [],
-    "flag-jm": [],
-    "flag-jo": [],
-    "flag-jp": [],
-    "flag-ke": [],
-    "flag-kg": [],
-    "flag-kh": [],
-    "flag-ki": [],
-    "flag-km": [],
-    "flag-kn": [],
-    "flag-kp": [],
-    "flag-kr": [],
-    "flag-kw": [],
-    "flag-ky": [],
-    "flag-kz": [],
-    "flag-la": [],
-    "flag-lb": [],
-    "flag-lc": [],
-    "flag-li": [],
-    "flag-lk": [],
-    "flag-lr": [],
-    "flag-ls": [],
-    "flag-lt": [],
-    "flag-lu": [],
-    "flag-lv": [],
-    "flag-ly": [],
-    "flag-ma": [],
-    "flag-mc": [],
-    "flag-md": [],
-    "flag-me": [],
-    "flag-mf": [],
-    "flag-mg": [],
-    "flag-mh": [],
-    "flag-mk": [],
-    "flag-ml": [],
-    "flag-mm": [],
-    "flag-mn": [],
-    "flag-mo": [],
-    "flag-mp": [],
-    "flag-mq": [],
-    "flag-mr": [],
-    "flag-ms": [],
-    "flag-mt": [],
-    "flag-mu": [],
-    "flag-mv": [],
-    "flag-mw": [],
-    "flag-mx": [],
-    "flag-my": [],
-    "flag-mz": [],
-    "flag-na": [],
-    "flag-nc": [],
-    "flag-ne": [],
-    "flag-nf": [],
-    "flag-ng": [],
-    "flag-ni": [],
-    "flag-nl": [],
-    "flag-no": [],
-    "flag-np": [],
-    "flag-nr": [],
-    "flag-nu": [],
-    "flag-nz": [],
-    "flag-om": [],
-    "flag-pa": [],
-    "flag-pe": [],
-    "flag-pf": [],
-    "flag-pg": [],
-    "flag-ph": [],
-    "flag-pk": [],
-    "flag-pl": [],
-    "flag-pm": [],
-    "flag-pn": [],
-    "flag-pr": [],
-    "flag-ps": [],
-    "flag-pt": [],
-    "flag-pw": [],
-    "flag-py": [],
-    "flag-qa": [],
-    "flag-re": [],
-    "flag-ro": [],
-    "flag-rs": [],
-    "flag-ru": [],
-    "flag-rw": [],
-    "flag-sa": [],
-    "flag-sb": [],
-    "flag-sc": [],
-    "flag-sd": [],
-    "flag-se": [],
-    "flag-sg": [],
-    "flag-sh": [],
-    "flag-si": [],
-    "flag-sj": [],
-    "flag-sk": [],
-    "flag-sl": [],
-    "flag-sm": [],
-    "flag-sn": [],
-    "flag-so": [],
-    "flag-sr": [],
-    "flag-ss": [],
-    "flag-st": [],
-    "flag-sv": [],
-    "flag-sx": [],
-    "flag-sy": [],
-    "flag-sz": [],
-    "flag-ta": [],
-    "flag-tc": [],
-    "flag-td": [],
-    "flag-tf": [],
-    "flag-tg": [],
-    "flag-th": [],
-    "flag-tj": [],
-    "flag-tk": [],
-    "flag-tl": [],
-    "flag-tm": [],
-    "flag-tn": [],
-    "flag-to": [],
-    "flag-tr": [],
-    "flag-tt": [],
-    "flag-tv": [],
-    "flag-tw": [],
-    "flag-tz": [],
-    "flag-ua": [],
-    "flag-ug": [],
-    "flag-um": [],
-    "flag-us": [],
-    "flag-uy": [],
-    "flag-uz": [],
-    "flag-va": [],
-    "flag-vc": [],
-    "flag-ve": [],
-    "flag-vg": [],
-    "flag-vi": [],
-    "flag-vn": [],
-    "flag-vu": [],
-    "flag-wf": [],
-    "flag-ws": [],
-    "flag-xk": [],
-    "flag-ye": [],
-    "flag-yt": [],
-    "flag-za": [],
-    "flag-zm": [],
-    "flag-zw": [],
-    "flags":[
-        "http://digitalcollections.nypl.org/items/510d47d9-8427-a3d9-e040-e00a18064a99"
-    ],
-    "flashlight":[
-        "http://digitalcollections.nypl.org/items/9a622aeb-9096-d2a0-e040-e00a180601cc",
-        "http://digitalcollections.nypl.org/items/510d47da-4eff-a3d9-e040-e00a18064a99"
-    ],
-    "fleur_de_lis":[
+    "⚜": [
         "http://digitalcollections.nypl.org/items/510d47e0-d0d9-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e1-0183-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e1-0181-a3d9-e040-e00a18064a99",
@@ -1316,148 +227,1120 @@
         "http://digitalcollections.nypl.org/items/510d47e1-018e-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e4-411e-a3d9-e040-e00a18064a99"
     ],
-    "flipper": [],
-    "floppy_disk": [],
-    "flower_playing_cards":[
-        "http://digitalcollections.nypl.org/items/510d47da-bed4-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-b455-a3d9-e040-e00a18064a99"
+    "⚠️": [],
+    "⚡️": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e1ed-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47da-d0d2-a3d9-e040-e00a18064a99"
     ],
-    "flushed": [
-        "http://digitalcollections.nypl.org/items/510d47e2-f713-a3d9-e040-e00a18064a99"
+    "⚪️": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-2730-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47dc-4405-a3d9-e040-e00a18064a99"
     ],
-    "fog":[
-        "http://digitalcollections.nypl.org/items/510d47e2-1db8-a3d9-e040-e00a18064a99"
+    "⚫️": [],
+    "⚰": [
+        "http://digitalcollections.nypl.org/items/acfeeb2d-78cf-4ce7-e040-e00a180644aa"
     ],
-    "foggy":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a04e-a3d9-e040-e00a18064a99"
+    "⚱": [
+        "http://digitalcollections.nypl.org/items/510d47e1-0054-a3d9-e040-e00a18064a99"
     ],
-    "football":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-7e14-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-8e8d-d471-e040-e00a180654d7"
+    "⚽️": [
+        "http://digitalcollections.nypl.org/items/510d47da-682c-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47df-a745-a3d9-e040-e00a18064a99"
     ],
-    "footprints":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-17cc-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-17cc-d471-e040-e00a180654d7"
+    "⚾️": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a9f9-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-c0e5-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-c101-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-c08f-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e4-0fee-a3d9-e040-e00a18064a99"
     ],
-    "fork_and_knife":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-02a8-d471-e040-e00a180654d7"
+    "⛄️": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c451-d471-e040-e00a180654d7"
     ],
-    "fountain":[
+    "⛅️": [
+        "http://digitalcollections.nypl.org/items/510d47e1-a562-a3d9-e040-e00a18064a99"
+    ],
+    "⛈": [],
+    "⛎": [
+        "http://digitalcollections.nypl.org/items/510d47dc-8dc1-a3d9-e040-e00a18064a99"
+    ],
+    "⛏": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e4a0-a3d9-e040-e00a18064a99"
+    ],
+    "⛑": [],
+    "⛓": [
+        "http://digitalcollections.nypl.org/items/510d47e1-2499-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-2444-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-fc23-a3d9-e040-e00a18064a99"
+    ],
+    "⛔️": [
+        "http://digitalcollections.nypl.org/items/510d47da-d196-a3d9-e040-e00a18064a99"
+    ],
+    "⛩": [
+        "http://digitalcollections.nypl.org/items/c260bdb3-9b43-4552-e040-e00a18066d81",
+        "http://digitalcollections.nypl.org/items/c260bdb3-9b7c-4552-e040-e00a18066d81"
+    ],
+    "⛪️": [
+        "http://digitalcollections.nypl.org/items/510d47d9-5075-a3d9-e040-e00a18064a99"
+    ],
+    "⛰": [
+        "http://digitalcollections.nypl.org/items/510d47d9-3f32-a3d9-e040-e00a18064a99"
+    ],
+    "⛱": [
+        "http://digitalcollections.nypl.org/items/510d47df-f731-a3d9-e040-e00a18064a99"
+    ],
+    "⛲️": [
         "http://digitalcollections.nypl.org/items/510d47e1-3681-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47de-9534-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e2-8b47-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e2-8b3d-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e2-8b4b-a3d9-e040-e00a18064a99"
     ],
-    "four": [],
-    "four_leaf_clover":[
-        "http://digitalcollections.nypl.org/items/510d47db-850e-a3d9-e040-e00a18064a99"
+    "⛳️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-0e20-a3d9-e040-e00a18064a99"
     ],
-    "fr": [],
-    "frame_with_picture":[
-        "http://digitalcollections.nypl.org/items/5cf22630-9cbc-0131-4c57-58d385a7b928"
+    "⛴": [
+        "http://digitalcollections.nypl.org/items/510d47d9-cbba-a3d9-e040-e00a18064a99"
     ],
-    "free": [],
-    "fried_shrimp":[
-        "http://digitalcollections.nypl.org/items/510d47da-3e32-a3d9-e040-e00a18064a99"
+    "⛵️": [
+        "http://digitalcollections.nypl.org/items/510d47d9-baa0-a3d9-e040-e00a18064a99"
     ],
-    "fries": [],
-    "frog":[
-        "http://digitalcollections.nypl.org/items/510d47e3-9abe-a3d9-e040-e00a18064a99"
+    "⛷": [
+        "http://digitalcollections.nypl.org/items/510d47da-7947-a3d9-e040-e00a18064a99"
     ],
-    "frowning":[
-        "http://digitalcollections.nypl.org/items/510d47de-2a29-a3d9-e040-e00a18064a99"
+    "⛸": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-1673-d471-e040-e00a180654d7"
     ],
-    "fuelpump":[
+    "⛹": [
+        "http://digitalcollections.nypl.org/items/510d47d9-bbdd-a3d9-e040-e00a18064a99"
+    ],
+    "⛺️": [
+        "http://digitalcollections.nypl.org/items/510d47da-cff3-a3d9-e040-e00a18064a99"
+    ],
+    "⛽️": [
         "http://digitalcollections.nypl.org/items/510d47d9-4f8e-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/8011f340-ea71-0131-52ba-58d385a7bbd0"
     ],
-    "full_moon":[
+    "✂️": [
+        "http://digitalcollections.nypl.org/items/510d47d9-acc2-a3d9-e040-e00a18064a99"
+    ],
+    "✅": [],
+    "✈️": [
+        "http://digitalcollections.nypl.org/items/510d47d9-3de4-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-05f4-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-148c-d471-e040-e00a180654d7"
+    ],
+    "✉️": [
+        "http://digitalcollections.nypl.org/items/510d47df-f38a-a3d9-e040-e00a18064a99"
+    ],
+    "✊": [
+        "http://digitalcollections.nypl.org/items/510d47e3-cbcd-a3d9-e040-e00a18064a99"
+    ],
+    "✋": [
+        "http://digitalcollections.nypl.org/items/5e05e730-1f96-0134-91ec-00505686a51c",
+        "http://digitalcollections.nypl.org/items/510d47e4-72a5-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-3649-a3d9-e040-e00a18064a99"
+    ],
+    "✌️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-af8f-a3d9-e040-e00a18064a99"
+    ],
+    "✍": [
+        "http://digitalcollections.nypl.org/items/510d47db-d3dd-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47df-9f29-a3d9-e040-e00a18064a99"
+    ],
+    "✏️": [
+        "http://digitalcollections.nypl.org/items/40f7c3b0-7a59-0132-6cf1-58d385a7b928"
+    ],
+    "✒️": [
+        "http://digitalcollections.nypl.org/items/510d47db-cae7-a3d9-e040-e00a18064a99"
+    ],
+    "✔️": [
+        "http://digitalcollections.nypl.org/items/510d47da-5865-a3d9-e040-e00a18064a99"
+    ],
+    "✖️": [],
+    "✝": [],
+    "✡": [],
+    "✨": [
+        "http://digitalcollections.nypl.org/items/893c0fe7-81f4-ad5f-e040-e00a18064278"
+    ],
+    "✳️": [
+        "http://digitalcollections.nypl.org/items/510d47e1-1658-a3d9-e040-e00a18064a99"
+    ],
+    "✴️": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e81f-a3d9-e040-e00a18064a99"
+    ],
+    "❄️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9ac2-a3d9-e040-e00a18064a99"
+    ],
+    "❇️": [],
+    "❌": [],
+    "❎": [],
+    "❓": [
+        "http://digitalcollections.nypl.org/items/c6d5d0ca-e348-54db-e040-e00a18063df6"
+    ],
+    "❔": [],
+    "❕": [],
+    "❗️": [],
+    "❣": [],
+    "❤️": [
+        "http://digitalcollections.nypl.org/items/510d47db-c0bd-a3d9-e040-e00a18064a99"
+    ],
+    "➕": [
+        "http://digitalcollections.nypl.org/items/510d47e3-c58c-a3d9-e040-e00a18064a99"
+    ],
+    "➖": [],
+    "➗": [],
+    "➡️": [
+        "http://digitalcollections.nypl.org/items/510d47e4-37c9-a3d9-e040-e00a18064a99"
+    ],
+    "➰": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7b29-a3d9-e040-e00a18064a99"
+    ],
+    "➿": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-f9cc-d471-e040-e00a180654d7"
+    ],
+    "⤴️": [],
+    "⤵️": [],
+    "⬅️": [
+        "http://digitalcollections.nypl.org/items/98e5ff00-96b3-0133-1f93-00505686d14e"
+    ],
+    "⬆️": [],
+    "⬇️": [],
+    "⬛️": [
+        "http://digitalcollections.nypl.org/items/510d47dc-40eb-a3d9-e040-e00a18064a99"
+    ],
+    "⬜️": [],
+    "⭐️": [],
+    "⭕️": [],
+    "〰️": [
+        "http://digitalcollections.nypl.org/items/510d47da-9246-a3d9-e040-e00a18064a99"
+    ],
+    "〽️": [],
+    "㊗️": [],
+    "㊙️": [],
+    "🀄️": [],
+    "🃏": [
+        "http://digitalcollections.nypl.org/items/510d47e2-2d36-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47df-f5d5-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-85e4-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/a491dc20-fd7a-0132-f4a4-58d385a7bbd0"
+    ],
+    "🅰️": [
+        "http://digitalcollections.nypl.org/items/6b26eaac-2b9a-1da7-e040-e00a18062258"
+    ],
+    "🅱️": [
+        "http://digitalcollections.nypl.org/items/6b26eaac-2b9b-1da7-e040-e00a18062258"
+    ],
+    "🅾️": [
+        "http://digitalcollections.nypl.org/items/510d47dc-42bb-a3d9-e040-e00a18064a99"
+    ],
+    "🅿️": [
+        "http://digitalcollections.nypl.org/items/6b26eaac-2ba8-1da7-e040-e00a18062258"
+    ],
+    "🆎": [],
+    "🆑": [],
+    "🆒": [
+        "http://digitalcollections.nypl.org/items/39427570-089e-0133-a70f-58d385a7b928"
+    ],
+    "🆓": [],
+    "🆔": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-bcea-d471-e040-e00a180654d7"
+    ],
+    "🆕": [],
+    "🆖": [],
+    "🆗": [],
+    "🆘": [],
+    "🆙": [],
+    "🆚": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-bcde-d471-e040-e00a180654d7"
+    ],
+    "🇦🇨": [],
+    "🇦🇩": [],
+    "🇦🇪": [],
+    "🇦🇫": [],
+    "🇦🇬": [],
+    "🇦🇮": [],
+    "🇦🇱": [],
+    "🇦🇲": [],
+    "🇦🇴": [],
+    "🇦🇶": [],
+    "🇦🇷": [],
+    "🇦🇸": [],
+    "🇦🇹": [],
+    "🇦🇺": [],
+    "🇦🇼": [],
+    "🇦🇽": [],
+    "🇦🇿": [],
+    "🇧🇦": [],
+    "🇧🇧": [],
+    "🇧🇩": [],
+    "🇧🇪": [],
+    "🇧🇫": [],
+    "🇧🇬": [],
+    "🇧🇭": [],
+    "🇧🇮": [],
+    "🇧🇯": [],
+    "🇧🇱": [],
+    "🇧🇲": [],
+    "🇧🇳": [],
+    "🇧🇴": [],
+    "🇧🇶": [],
+    "🇧🇷": [],
+    "🇧🇸": [],
+    "🇧🇹": [],
+    "🇧🇻": [],
+    "🇧🇼": [],
+    "🇧🇾": [],
+    "🇧🇿": [],
+    "🇨🇦": [],
+    "🇨🇨": [],
+    "🇨🇩": [],
+    "🇨🇫": [],
+    "🇨🇬": [],
+    "🇨🇭": [],
+    "🇨🇮": [],
+    "🇨🇰": [],
+    "🇨🇱": [],
+    "🇨🇲": [],
+    "🇨🇳": [],
+    "🇨🇴": [],
+    "🇨🇵": [],
+    "🇨🇷": [],
+    "🇨🇺": [],
+    "🇨🇻": [],
+    "🇨🇼": [],
+    "🇨🇽": [],
+    "🇨🇾": [],
+    "🇨🇿": [],
+    "🇩🇪": [],
+    "🇩🇬": [],
+    "🇩🇯": [],
+    "🇩🇰": [],
+    "🇩🇲": [],
+    "🇩🇴": [],
+    "🇩🇿": [],
+    "🇪🇦": [],
+    "🇪🇨": [],
+    "🇪🇪": [],
+    "🇪🇬": [],
+    "🇪🇭": [],
+    "🇪🇷": [],
+    "🇪🇸": [],
+    "🇪🇹": [],
+    "🇪🇺": [],
+    "🇫🇮": [],
+    "🇫🇯": [],
+    "🇫🇰": [],
+    "🇫🇲": [],
+    "🇫🇴": [],
+    "🇫🇷": [],
+    "🇬🇦": [],
+    "🇬🇧": [],
+    "🇬🇩": [],
+    "🇬🇪": [],
+    "🇬🇫": [],
+    "🇬🇬": [],
+    "🇬🇭": [],
+    "🇬🇮": [],
+    "🇬🇱": [],
+    "🇬🇲": [],
+    "🇬🇳": [],
+    "🇬🇵": [],
+    "🇬🇶": [],
+    "🇬🇷": [],
+    "🇬🇸": [],
+    "🇬🇹": [],
+    "🇬🇺": [],
+    "🇬🇼": [],
+    "🇬🇾": [],
+    "🇭🇰": [],
+    "🇭🇲": [],
+    "🇭🇳": [],
+    "🇭🇷": [],
+    "🇭🇹": [],
+    "🇭🇺": [],
+    "🇮🇨": [],
+    "🇮🇩": [],
+    "🇮🇪": [],
+    "🇮🇱": [],
+    "🇮🇲": [],
+    "🇮🇳": [],
+    "🇮🇴": [],
+    "🇮🇶": [],
+    "🇮🇷": [],
+    "🇮🇸": [],
+    "🇮🇹": [],
+    "🇯🇪": [],
+    "🇯🇲": [],
+    "🇯🇴": [],
+    "🇯🇵": [],
+    "🇰🇪": [],
+    "🇰🇬": [],
+    "🇰🇭": [],
+    "🇰🇮": [],
+    "🇰🇲": [],
+    "🇰🇳": [],
+    "🇰🇵": [],
+    "🇰🇷": [],
+    "🇰🇼": [],
+    "🇰🇾": [],
+    "🇰🇿": [],
+    "🇱🇦": [],
+    "🇱🇧": [],
+    "🇱🇨": [],
+    "🇱🇮": [],
+    "🇱🇰": [],
+    "🇱🇷": [],
+    "🇱🇸": [],
+    "🇱🇹": [],
+    "🇱🇺": [],
+    "🇱🇻": [],
+    "🇱🇾": [],
+    "🇲🇦": [],
+    "🇲🇨": [],
+    "🇲🇩": [],
+    "🇲🇪": [],
+    "🇲🇫": [],
+    "🇲🇬": [],
+    "🇲🇭": [],
+    "🇲🇰": [],
+    "🇲🇱": [],
+    "🇲🇲": [],
+    "🇲🇳": [],
+    "🇲🇴": [],
+    "🇲🇵": [],
+    "🇲🇶": [],
+    "🇲🇷": [],
+    "🇲🇸": [],
+    "🇲🇹": [],
+    "🇲🇺": [],
+    "🇲🇻": [],
+    "🇲🇼": [],
+    "🇲🇽": [],
+    "🇲🇾": [],
+    "🇲🇿": [],
+    "🇳🇦": [],
+    "🇳🇨": [],
+    "🇳🇪": [],
+    "🇳🇫": [],
+    "🇳🇬": [],
+    "🇳🇮": [],
+    "🇳🇱": [],
+    "🇳🇴": [],
+    "🇳🇵": [],
+    "🇳🇷": [],
+    "🇳🇺": [],
+    "🇳🇿": [],
+    "🇴🇲": [],
+    "🇵🇦": [],
+    "🇵🇪": [],
+    "🇵🇫": [],
+    "🇵🇬": [],
+    "🇵🇭": [],
+    "🇵🇰": [],
+    "🇵🇱": [],
+    "🇵🇲": [],
+    "🇵🇳": [],
+    "🇵🇷": [],
+    "🇵🇸": [],
+    "🇵🇹": [],
+    "🇵🇼": [],
+    "🇵🇾": [],
+    "🇶🇦": [],
+    "🇷🇪": [],
+    "🇷🇴": [],
+    "🇷🇸": [],
+    "🇷🇺": [],
+    "🇷🇼": [],
+    "🇸🇦": [],
+    "🇸🇧": [],
+    "🇸🇨": [],
+    "🇸🇩": [],
+    "🇸🇪": [],
+    "🇸🇬": [],
+    "🇸🇭": [],
+    "🇸🇮": [],
+    "🇸🇯": [],
+    "🇸🇰": [],
+    "🇸🇱": [],
+    "🇸🇲": [],
+    "🇸🇳": [],
+    "🇸🇴": [],
+    "🇸🇷": [],
+    "🇸🇸": [],
+    "🇸🇹": [],
+    "🇸🇻": [],
+    "🇸🇽": [],
+    "🇸🇾": [],
+    "🇸🇿": [],
+    "🇹🇦": [],
+    "🇹🇨": [],
+    "🇹🇩": [],
+    "🇹🇫": [],
+    "🇹🇬": [],
+    "🇹🇭": [],
+    "🇹🇯": [],
+    "🇹🇰": [],
+    "🇹🇱": [],
+    "🇹🇲": [],
+    "🇹🇳": [],
+    "🇹🇴": [],
+    "🇹🇷": [],
+    "🇹🇹": [],
+    "🇹🇻": [],
+    "🇹🇼": [],
+    "🇹🇿": [],
+    "🇺🇦": [],
+    "🇺🇬": [],
+    "🇺🇲": [],
+    "🇺🇸": [],
+    "🇺🇾": [],
+    "🇺🇿": [],
+    "🇻🇦": [],
+    "🇻🇨": [],
+    "🇻🇪": [],
+    "🇻🇬": [],
+    "🇻🇮": [],
+    "🇻🇳": [],
+    "🇻🇺": [],
+    "🇼🇫": [],
+    "🇼🇸": [],
+    "🇽🇰": [],
+    "🇾🇪": [],
+    "🇾🇹": [],
+    "🇿🇦": [],
+    "🇿🇲": [],
+    "🇿🇼": [],
+    "🈁": [],
+    "🈂️": [],
+    "🈚️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈯️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈲": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈳": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈴": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈵": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈶": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈷️": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈸": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈹": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🈺": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
+        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
+    ],
+    "🉐": [],
+    "🉑": [],
+    "🌀": [
+        "http://digitalcollections.nypl.org/items/510d47d9-aa8a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-5225-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-c2f9-a3d9-e040-e00a18064a99"
+    ],
+    "🌁": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a04e-a3d9-e040-e00a18064a99"
+    ],
+    "🌂": [
+        "http://digitalcollections.nypl.org/items/510d47db-1b31-a3d9-e040-e00a18064a99"
+    ],
+    "🌃": [
+        "http://digitalcollections.nypl.org/items/510d47dd-a825-a3d9-e040-e00a18064a99"
+    ],
+    "🌄": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a35a-a3d9-e040-e00a18064a99"
+    ],
+    "🌅": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a185-a3d9-e040-e00a18064a99"
+    ],
+    "🌆": [
+        "http://digitalcollections.nypl.org/items/510d47e2-8e15-a3d9-e040-e00a18064a99"
+    ],
+    "🌇": [
+        "http://digitalcollections.nypl.org/items/510d47e2-8b0b-a3d9-e040-e00a18064a99"
+    ],
+    "🌈": [
+        "http://digitalcollections.nypl.org/items/510d47e2-49a1-a3d9-e040-e00a18064a99"
+    ],
+    "🌉": [
+        "http://digitalcollections.nypl.org/items/510d47e1-2d11-a3d9-e040-e00a18064a99"
+    ],
+    "🌊": [
+        "http://digitalcollections.nypl.org/items/510d47e0-cafa-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e4-7608-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e0-cb1f-a3d9-e040-e00a18064a99"
+    ],
+    "🌋": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-d816-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47d9-83cd-a3d9-e040-e00a18064a99"
+    ],
+    "🌌": [
+        "http://digitalcollections.nypl.org/items/510d47db-d3ea-a3d9-e040-e00a18064a99"
+    ],
+    "🌍": [
+        "http://digitalcollections.nypl.org/items/b631ab46-2320-5c16-e040-e00a18064aaf"
+    ],
+    "🌎": [
+        "http://digitalcollections.nypl.org/items/b631fc9e-4ea3-7f06-e040-e00a18064f89"
+    ],
+    "🌏": [
+        "http://digitalcollections.nypl.org/items/b631aa51-b8a6-847c-e040-e00a18064b4a"
+    ],
+    "🌐": [
+        "http://digitalcollections.nypl.org/items/916a9a3c-d7d1-708f-e040-e00a180608a0"
+    ],
+    "🌑": [
         "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
     ],
-    "full_moon_with_face":[
+    "🌒": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌓": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌔": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌕": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌖": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌗": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌘": [
+        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    ],
+    "🌙": [
+        "http://digitalcollections.nypl.org/items/510d47df-f210-a3d9-e040-e00a18064a99"
+    ],
+    "🌚": [
+        "http://digitalcollections.nypl.org/items/890277b9-4331-5552-e040-e00a18065ce4"
+    ],
+    "🌛": [
+        "http://digitalcollections.nypl.org/items/96c1c508-1f08-dfa7-e040-e00a1806799d"
+    ],
+    "🌜": [
+        "http://digitalcollections.nypl.org/items/96c1c508-1f08-dfa7-e040-e00a1806799d"
+    ],
+    "🌝": [
         "http://digitalcollections.nypl.org/items/510d47de-1744-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47de-3a89-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/f4fe1af0-b19e-0133-7f4e-00505686a51c",
         "http://digitalcollections.nypl.org/items/510d47de-16f7-a3d9-e040-e00a18064a99"
     ],
-    "funeral_urn":[
-        "http://digitalcollections.nypl.org/items/510d47e1-0054-a3d9-e040-e00a18064a99"
+    "🌞": [
+        "http://digitalcollections.nypl.org/items/a2dce264-6010-361b-e040-e00a18060eae",
+        "http://digitalcollections.nypl.org/items/510d47e1-165a-a3d9-e040-e00a18064a99"
     ],
-    "game_die":[
-        "http://digitalcollections.nypl.org/items/510d47e2-ee71-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/ae2f51ec-bf81-66c6-e040-e00a18066cf3"
+    "🌟": [
+        "http://digitalcollections.nypl.org/items/510d47e3-2b9a-a3d9-e040-e00a18064a99"
     ],
-    "gb": [],
-    "gear":[
-        "http://digitalcollections.nypl.org/items/510d47e4-41f1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e4-7b01-a3d9-e040-e00a18064a99"
+    "🌠": [
+        "http://digitalcollections.nypl.org/items/510d47e2-49ad-a3d9-e040-e00a18064a99"
     ],
-    "gem":[
-        "http://digitalcollections.nypl.org/items/510d47e2-45d2-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-45d8-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-45d0-a3d9-e040-e00a18064a99"
+    "🌡": [
+        "http://digitalcollections.nypl.org/items/510d47dd-f3bf-a3d9-e040-e00a18064a99"
     ],
-    "gemini":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7047-a3d9-e040-e00a18064a99"
+    "🌤": [
+        "http://digitalcollections.nypl.org/items/b1e3b2f0-e051-0131-0cca-58d385a7b928"
     ],
-    "ghost":[
-        "http://digitalcollections.nypl.org/items/fd54ee00-82b7-0130-a9f2-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47e2-c549-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-c54a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-c54d-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-c507-a3d9-e040-e00a18064a99"
+    "🌥": [
+        "http://digitalcollections.nypl.org/items/62ed7b00-a107-0132-c608-58d385a7b928"
     ],
-    "gift":[
+    "🌦": [],
+    "🌧": [
+        "http://digitalcollections.nypl.org/items/510d47e3-585b-a3d9-e040-e00a18064a99"
+    ],
+    "🌨": [
+        "http://digitalcollections.nypl.org/items/510d47e1-946c-a3d9-e040-e00a18064a99"
+    ],
+    "🌩": [
+        "http://digitalcollections.nypl.org/items/510d47e0-f95f-a3d9-e040-e00a18064a99"
+    ],
+    "🌪": [
+        "http://digitalcollections.nypl.org/items/510d47d9-aa8a-a3d9-e040-e00a18064a99"
+    ],
+    "🌫": [
+        "http://digitalcollections.nypl.org/items/510d47e2-1db8-a3d9-e040-e00a18064a99"
+    ],
+    "🌬": [
+        "http://digitalcollections.nypl.org/items/510d47e4-736a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e4-1d1c-a3d9-e040-e00a18064a99"
+    ],
+    "🌭": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-86a3-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47df-3360-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e0-db21-a3d9-e040-e00a18064a99"
+    ],
+    "🌮": [
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-57c6-f55a-e040-e00a18062565"
+    ],
+    "🌯": [
+        "http://digitalcollections.nypl.org/items/510d47de-ae8b-a3d9-e040-e00a18064a99"
+    ],
+    "🌰": [
+        "http://digitalcollections.nypl.org/items/510d47de-5d8d-a3d9-e040-e00a18064a99"
+    ],
+    "🌱": [
+        "http://digitalcollections.nypl.org/items/510d47e3-c056-a3d9-e040-e00a18064a99"
+    ],
+    "🌲": [
+        "http://digitalcollections.nypl.org/items/510d47de-5f87-a3d9-e040-e00a18064a99"
+    ],
+    "🌳": [
+        "http://digitalcollections.nypl.org/items/510d47de-5f93-a3d9-e040-e00a18064a99"
+    ],
+    "🌴": [
+        "http://digitalcollections.nypl.org/items/510d47dc-8dc6-a3d9-e040-e00a18064a99"
+    ],
+    "🌵": [
+        "http://digitalcollections.nypl.org/items/510d47d9-9d74-a3d9-e040-e00a18064a99"
+    ],
+    "🌶": [
+        "http://digitalcollections.nypl.org/items/510d47df-f6d8-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-37d5-a3d9-e040-e00a18064a99"
+    ],
+    "🌷": [
+        "http://digitalcollections.nypl.org/items/510d47dd-ee52-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-f17a-a3d9-e040-e00a18064a99"
+    ],
+    "🌸": [
+        "http://digitalcollections.nypl.org/items/510d47e1-cae3-a3d9-e040-e00a18064a99"
+    ],
+    "🌹": [
+        "http://digitalcollections.nypl.org/items/510d47da-ce9c-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-4175-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-65be-a3d9-e040-e00a18064a99"
+    ],
+    "🌺": [
+        "http://digitalcollections.nypl.org/items/510d47dc-926e-a3d9-e040-e00a18064a99"
+    ],
+    "🌻": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6618-a3d9-e040-e00a18064a99"
+    ],
+    "🌼": [
+        "http://digitalcollections.nypl.org/items/510d47e3-358d-a3d9-e040-e00a18064a99"
+    ],
+    "🌽": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6477-a3d9-e040-e00a18064a99"
+    ],
+    "🌾": [
+        "http://digitalcollections.nypl.org/items/510d47e0-11aa-a3d9-e040-e00a18064a99"
+    ],
+    "🌿": [
+        "http://digitalcollections.nypl.org/items/510d47dd-c5b0-a3d9-e040-e00a18064a99"
+    ],
+    "🍀": [
+        "http://digitalcollections.nypl.org/items/510d47db-850e-a3d9-e040-e00a18064a99"
+    ],
+    "🍁": [
+        "http://digitalcollections.nypl.org/items/510d47e0-0874-a3d9-e040-e00a18064a99"
+    ],
+    "🍂": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7a6f-a3d9-e040-e00a18064a99"
+    ],
+    "🍃": [
+        "http://digitalcollections.nypl.org/items/510d47e4-1050-a3d9-e040-e00a18064a99"
+    ],
+    "🍄": [
+        "http://digitalcollections.nypl.org/items/510d47e2-dee0-a3d9-e040-e00a18064a99"
+    ],
+    "🍅": [
+        "http://digitalcollections.nypl.org/items/510d47dd-c6b1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-5859-f55a-e040-e00a18062565"
+    ],
+    "🍆": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f5a8-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dc-7c97-a3d9-e040-e00a18064a99"
+    ],
+    "🍇": [
+        "http://digitalcollections.nypl.org/items/510d47dc-892e-a3d9-e040-e00a18064a99"
+    ],
+    "🍈": [
+        "http://digitalcollections.nypl.org/items/510d47dc-7de3-a3d9-e040-e00a18064a99"
+    ],
+    "🍉": [
+        "http://digitalcollections.nypl.org/items/510d47db-5173-a3d9-e040-e00a18064a99"
+    ],
+    "🍊": [
+        "http://digitalcollections.nypl.org/items/510d47dc-93c6-a3d9-e040-e00a18064a99"
+    ],
+    "🍋": [
+        "http://digitalcollections.nypl.org/items/510d47dc-9395-a3d9-e040-e00a18064a99"
+    ],
+    "🍌": [
+        "http://digitalcollections.nypl.org/items/510d47dd-f132-a3d9-e040-e00a18064a99"
+    ],
+    "🍍": [
+        "http://digitalcollections.nypl.org/items/510d47dd-c3f0-a3d9-e040-e00a18064a99"
+    ],
+    "🍎": [
+        "http://digitalcollections.nypl.org/items/510d47de-5d7f-a3d9-e040-e00a18064a99"
+    ],
+    "🍏": [
+        "http://digitalcollections.nypl.org/items/510d47db-5802-a3d9-e040-e00a18064a99"
+    ],
+    "🍐": [
+        "http://digitalcollections.nypl.org/items/510d47dd-d91d-a3d9-e040-e00a18064a99"
+    ],
+    "🍑": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e29c-a3d9-e040-e00a18064a99"
+    ],
+    "🍒": [
+        "http://digitalcollections.nypl.org/items/510d47dd-d8d5-a3d9-e040-e00a18064a99"
+    ],
+    "🍓": [
+        "http://digitalcollections.nypl.org/items/510d47da-93b9-a3d9-e040-e00a18064a99"
+    ],
+    "🍔": [
+        "http://digitalcollections.nypl.org/items/7e1b1060-6215-0132-5953-58d385a7bbd0"
+    ],
+    "🍕": [
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-555e-f55a-e040-e00a18062565",
+        "http://digitalcollections.nypl.org/items/ae2f51ec-bfc7-66c6-e040-e00a18066cf3",
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-5876-f55a-e040-e00a18062565"
+    ],
+    "🍖": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e177-d471-e040-e00a180654d7"
+    ],
+    "🍗": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6485-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-bfe5-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-eea7-d471-e040-e00a180654d7"
+    ],
+    "🍘": [],
+    "🍙": [
+        "http://digitalcollections.nypl.org/items/a6249ebc-895b-849c-e040-e00a18060616"
+    ],
+    "🍚": [
+        "http://digitalcollections.nypl.org/items/c261ef12-e4cc-3577-e040-e00a18067776"
+    ],
+    "🍛": [
+        "http://digitalcollections.nypl.org/items/510d47db-4f05-a3d9-e040-e00a18064a99"
+    ],
+    "🍜": [
+        "http://digitalcollections.nypl.org/items/ba355981-5687-de30-e040-e00a1806351c"
+    ],
+    "🍝": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-f2ef-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-598e-f55a-e040-e00a18062565"
+    ],
+    "🍞": [
+        "http://digitalcollections.nypl.org/items/bb13368d-1df6-86eb-e040-e00a18066010"
+    ],
+    "🍟": [],
+    "🍠": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ced9-d471-e040-e00a180654d7"
+    ],
+    "🍡": [],
+    "🍢": [],
+    "🍣": [
+        "http://digitalcollections.nypl.org/items/d31499a0-3f63-0131-276a-58d385a7bbd0"
+    ],
+    "🍤": [
+        "http://digitalcollections.nypl.org/items/510d47da-3e32-a3d9-e040-e00a18064a99"
+    ],
+    "🍥": [],
+    "🍦": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-b580-d471-e040-e00a180654d7"
+    ],
+    "🍧": [
+        "http://digitalcollections.nypl.org/items/7b07ea5c-622b-6b59-e040-e00a18065a4d"
+    ],
+    "🍨": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-b580-d471-e040-e00a180654d7"
+    ],
+    "🍩": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-801e-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-2890-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/ba355981-5685-de30-e040-e00a1806351c"
+    ],
+    "🍪": [
+        "http://digitalcollections.nypl.org/items/510d47de-3ae1-a3d9-e040-e00a18064a99"
+    ],
+    "🍫": [
+        "http://digitalcollections.nypl.org/items/510d47e1-20a0-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-a987-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-b510-a3d9-e040-e00a18064a99"
+    ],
+    "🍬": [
+        "http://digitalcollections.nypl.org/items/ccd47a10-21ce-0133-43a7-58d385a7b928"
+    ],
+    "🍭": [],
+    "🍮": [
+        "http://digitalcollections.nypl.org/items/510d47de-3aed-a3d9-e040-e00a18064a99"
+    ],
+    "🍯": [
+        "http://digitalcollections.nypl.org/items/510d47e1-43ee-a3d9-e040-e00a18064a99"
+    ],
+    "🍰": [
+        "http://digitalcollections.nypl.org/items/61bb8540-c759-0132-e6ba-58d385a7bbd0"
+    ],
+    "🍱": [
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-5837-f55a-e040-e00a18062565"
+    ],
+    "🍲": [
+        "http://digitalcollections.nypl.org/items/afbf98ff-4766-7e08-e040-e00a18064829"
+    ],
+    "🍳": [
+        "http://digitalcollections.nypl.org/items/510d47de-3b0b-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47de-3881-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-29d8-d471-e040-e00a180654d7"
+    ],
+    "🍴": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-02a8-d471-e040-e00a180654d7"
+    ],
+    "🍵": [
+        "http://digitalcollections.nypl.org/items/510d47dc-3eea-a3d9-e040-e00a18064a99"
+    ],
+    "🍶": [
+        "http://digitalcollections.nypl.org/items/510d47d9-83a9-a3d9-e040-e00a18064a99"
+    ],
+    "🍷": [
+        "http://digitalcollections.nypl.org/items/510d47e3-accc-a3d9-e040-e00a18064a99"
+    ],
+    "🍸": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-0b29-d471-e040-e00a180654d7"
+    ],
+    "🍹": [
+        "http://digitalcollections.nypl.org/items/a4d03826-f1e0-a5c7-e040-e00a18066166",
+        "http://digitalcollections.nypl.org/items/af1f02d7-5606-ce42-e040-e00a18064e03"
+    ],
+    "🍺": [
+        "http://digitalcollections.nypl.org/items/510d47dd-eaad-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-37a0-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/fb711ca0-0f56-0131-af7a-58d385a7b928"
+    ],
+    "🍻": [
+        "http://digitalcollections.nypl.org/items/510d47e2-e51f-a3d9-e040-e00a18064a99"
+    ],
+    "🍼": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-a986-d471-e040-e00a180654d7"
+    ],
+    "🍽": [
+        "http://digitalcollections.nypl.org/items/510d47da-d7fa-a3d9-e040-e00a18064a99"
+    ],
+    "🍾": [
+        "http://digitalcollections.nypl.org/items/510d47db-3ec6-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-3be2-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-d810-a3d9-e040-e00a18064a99"
+    ],
+    "🍿": [
+        "http://digitalcollections.nypl.org/items/510d47dd-9e59-a3d9-e040-e00a18064a99"
+    ],
+    "🎀": [
+        "http://digitalcollections.nypl.org/items/510d47e3-b2e2-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-20d4-a3d9-e040-e00a18064a99"
+    ],
+    "🎁": [
         "http://digitalcollections.nypl.org/items/5e66b3e8-8316-d471-e040-e00a180654d7",
         "http://digitalcollections.nypl.org/items/510d47e3-6188-a3d9-e040-e00a18064a99"
     ],
-    "gift_heart":[
-        "http://digitalcollections.nypl.org/items/510d47e3-64c1-a3d9-e040-e00a18064a99"
+    "🎂": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-f5e4-d471-e040-e00a180654d7"
     ],
-    "girl":[
-        "http://digitalcollections.nypl.org/items/37013680-2289-0132-5553-58d385a7bbd0"
+    "🎃": [
+        "http://digitalcollections.nypl.org/items/b16926af-3fe3-6b2f-e040-e00a1806531a"
     ],
-    "globe_with_meridians":[
-        "http://digitalcollections.nypl.org/items/916a9a3c-d7d1-708f-e040-e00a180608a0"
+    "🎄": [
+        "http://digitalcollections.nypl.org/items/510d47e3-67b9-a3d9-e040-e00a18064a99"
     ],
-    "goat":[
-        "http://digitalcollections.nypl.org/items/510d47e2-d4a4-a3d9-e040-e00a18064a99"
+    "🎅": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6f94-a3d9-e040-e00a18064a99"
     ],
-    "golf":[
-        "http://digitalcollections.nypl.org/items/510d47e4-0e20-a3d9-e040-e00a18064a99"
+    "🎆": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-aaa1-d471-e040-e00a180654d7"
     ],
-    "golfer":[
-        "http://digitalcollections.nypl.org/items/510d47e0-fe61-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-4662-a3d9-e040-e00a18064a99"
+    "🎇": [
+        "http://digitalcollections.nypl.org/items/510d47e3-4763-a3d9-e040-e00a18064a99"
     ],
-    "grapes":[
-        "http://digitalcollections.nypl.org/items/510d47dc-892e-a3d9-e040-e00a18064a99"
+    "🎈": [
+        "http://digitalcollections.nypl.org/items/62a69ae1-2c09-b619-e040-e00a18062f9c"
     ],
-    "green_apple":[
-        "http://digitalcollections.nypl.org/items/510d47db-5802-a3d9-e040-e00a18064a99"
+    "🎉": [
+        "http://digitalcollections.nypl.org/items/510d47da-4a5b-a3d9-e040-e00a18064a99"
     ],
-    "green_book":[
-        "http://digitalcollections.nypl.org/items/dc858e50-83d3-0132-2266-58d385a7b928"
+    "🎊": [
+        "http://digitalcollections.nypl.org/items/510d47e2-d1aa-a3d9-e040-e00a18064a99"
     ],
-    "green_heart": [
-        "http://digitalcollections.nypl.org/items/510d47e3-64c7-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-6198-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-64d3-a3d9-e040-e00a18064a99"    
+    "🎋": [],
+    "🎌": [
+        "http://digitalcollections.nypl.org/items/510d47da-d1d4-a3d9-e040-e00a18064a99"
     ],
-    "grey_exclamation": [],
-    "grey_question": [],
-    "grimacing":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-759b-3443-e040-e00a18067692"
+    "🎍": [
+        "http://digitalcollections.nypl.org/items/510d47d9-841a-a3d9-e040-e00a18064a99"
     ],
-    "grin":[
-        "http://digitalcollections.nypl.org/items/0b834ba0-e8f3-0130-12cc-58d385a7bbd0"
+    "🎎": [
+        "http://digitalcollections.nypl.org/items/c261ef12-e4d4-3577-e040-e00a18067776"
     ],
-    "grinning": [],
-    "guardsman":[
-        "http://digitalcollections.nypl.org/items/510d47e0-e627-a3d9-e040-e00a18064a99"
+    "🎏": [
+        "http://digitalcollections.nypl.org/items/510d47d9-8427-a3d9-e040-e00a18064a99"
     ],
-    "guitar":[
+    "🎐": [
+        "http://digitalcollections.nypl.org/items/510d47e4-643b-a3d9-e040-e00a18064a99"
+    ],
+    "🎑": [
+        "http://digitalcollections.nypl.org/items/510d47e1-cc3a-a3d9-e040-e00a18064a99"
+    ],
+    "🎒": [
+        "http://digitalcollections.nypl.org/items/510d47e0-e282-a3d9-e040-e00a18064a99"
+    ],
+    "🎓": [
+        "http://digitalcollections.nypl.org/items/510d47e0-f03d-a3d9-e040-e00a18064a99"
+    ],
+    "🎖": [
+        "http://digitalcollections.nypl.org/items/510d47e2-1950-a3d9-e040-e00a18064a99"
+    ],
+    "🎗": [],
+    "🎙": [
+        "http://digitalcollections.nypl.org/items/9e78418c-529f-94eb-e040-e00a180656ef",
+        "http://digitalcollections.nypl.org/items/7b8172c8-b46c-d1a9-e040-e00a1806198a"
+    ],
+    "🎚": [],
+    "🎛": [
+        "http://digitalcollections.nypl.org/items/510d47de-5f5b-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-e908-a3d9-e040-e00a18064a99"
+    ],
+    "🎞": [
+        "http://digitalcollections.nypl.org/items/44a6a410-ccdd-0132-8a1f-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/a7485830-ccdd-0132-5a26-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/6d5d1960-ccdd-0132-4dbd-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/f96a3440-ccdd-0132-4545-58d385a7bbd0"
+    ],
+    "🎟": [
+        "http://digitalcollections.nypl.org/items/8fabffd8-1b8e-7d20-e040-e00a180638f4",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-1f56-d471-e040-e00a180654d7"
+    ],
+    "🎠": [
+        "http://digitalcollections.nypl.org/items/7b58749c-8e91-480a-e040-e00a180668d3"
+    ],
+    "🎡": [
+        "http://digitalcollections.nypl.org/items/510d47dd-f4cc-a3d9-e040-e00a18064a99"
+    ],
+    "🎢": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-1664-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47d9-cc19-a3d9-e040-e00a18064a99"
+    ],
+    "🎣": [
+        "http://digitalcollections.nypl.org/items/510d47da-991c-a3d9-e040-e00a18064a99"
+    ],
+    "🎤": [
+        "http://digitalcollections.nypl.org/items/a27ad31f-c170-9bd4-e040-e00a18067343",
+        "http://digitalcollections.nypl.org/items/9be9e150-5eb6-0131-0b36-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-9fdd-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/8caac9b0-d13f-0130-21ba-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/6e7d64e0-7df9-0130-1dbf-58d385a7bbd0"
+    ],
+    "🎥": [
+        "http://digitalcollections.nypl.org/items/510d47da-930b-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47de-ab6c-a3d9-e040-e00a18064a99"
+    ],
+    "🎦": [
+        "http://digitalcollections.nypl.org/items/a15fc5c4-8411-f36d-e040-e00a18062fdc",
+        "http://digitalcollections.nypl.org/items/63abe500-00a5-0133-0a70-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/83d56b71-44fb-2a82-e040-e00a1806337f",
+        "http://digitalcollections.nypl.org/items/dd8bab80-00a4-0133-c481-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/27734160-00a5-0133-905f-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47df-f986-a3d9-e040-e00a18064a99"
+    ],
+    "🎧": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7be3-a3d9-e040-e00a18064a99"
+    ],
+    "🎨": [
+        "http://digitalcollections.nypl.org/items/8f4a4f7b-fc8d-6b2c-e040-e00a180672e1"
+    ],
+    "🎩": [
+        "http://digitalcollections.nypl.org/items/510d47e1-22ac-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/498edbb0-1f93-0134-eeac-00505686a51c",
+        "http://digitalcollections.nypl.org/items/510d47e1-221b-a3d9-e040-e00a18064a99"
+    ],
+    "🎪": [
+        "http://digitalcollections.nypl.org/items/b7ece31d-7f99-8808-e040-e00a18063f2c"
+    ],
+    "🎫": [
+        "http://digitalcollections.nypl.org/items/510d47df-75f2-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c99d-d471-e040-e00a180654d7"
+    ],
+    "🎬": [
+        "http://digitalcollections.nypl.org/items/510d47e4-786e-a3d9-e040-e00a18064a99"
+    ],
+    "🎭": [
+        "http://digitalcollections.nypl.org/items/510d47e4-1a23-a3d9-e040-e00a18064a99"
+    ],
+    "🎮": [
+        "http://digitalcollections.nypl.org/items/510d47dc-ea03-a3d9-e040-e00a18064a99"
+    ],
+    "🎯": [
+        "http://digitalcollections.nypl.org/items/510d47e3-afa1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-d198-a3d9-e040-e00a18064a99"
+    ],
+    "🎰": [],
+    "🎱": [
+        "http://digitalcollections.nypl.org/items/510d47de-7680-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47de-75ba-a3d9-e040-e00a18064a99"
+    ],
+    "🎲": [
+        "http://digitalcollections.nypl.org/items/510d47e2-ee71-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/ae2f51ec-bf81-66c6-e040-e00a18066cf3"
+    ],
+    "🎳": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4d88-a3d9-e040-e00a18064a99"
+    ],
+    "🎴": [
+        "http://digitalcollections.nypl.org/items/510d47da-bed4-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-b455-a3d9-e040-e00a18064a99"
+    ],
+    "🎵": [
+        "http://digitalcollections.nypl.org/items/a50e602d-63d5-f9b6-e040-e00a180649c6"
+    ],
+    "🎶": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6dfa-a3d9-e040-e00a18064a99"
+    ],
+    "🎷": [
+        "http://digitalcollections.nypl.org/items/8be85efd-01c9-2a4b-e040-e00a18065153",
+        "http://digitalcollections.nypl.org/items/6284748f-2316-3fb4-e040-e00a180647d6"
+    ],
+    "🎸": [
         "http://digitalcollections.nypl.org/items/a7d0e925-f8fc-eff6-e040-e00a18060357",
         "http://digitalcollections.nypl.org/items/510d47e3-39d2-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e3-cc19-a3d9-e040-e00a18064a99",
@@ -1469,995 +1352,1863 @@
         "http://digitalcollections.nypl.org/items/510d47e3-3a3f-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/fb284090-8a83-0130-4739-58d385a7bbd0"
     ],
-    "gun":[
-        "http://digitalcollections.nypl.org/items/510d47e2-cda9-a3d9-e040-e00a18064a99"
+    "🎹": [
+        "http://digitalcollections.nypl.org/items/510d47d9-3cad-a3d9-e040-e00a18064a99"
     ],
-    "haircut":[
-        "http://digitalcollections.nypl.org/items/595ca3c0-964a-0130-2873-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/bbda5cb1-20b3-2132-e040-e00a18063b2f"
+    "🎺": [
+        "http://digitalcollections.nypl.org/items/6284748f-2319-3fb4-e040-e00a180647d6"
     ],
-    "hamburger":[
-        "http://digitalcollections.nypl.org/items/7e1b1060-6215-0132-5953-58d385a7bbd0"
+    "🎻": [
+        "http://digitalcollections.nypl.org/items/510d47e2-df18-a3d9-e040-e00a18064a99"
     ],
-    "hammer":[
-        "http://digitalcollections.nypl.org/items/510d47de-1ad3-a3d9-e040-e00a18064a99"
+    "🎼": [
+        "http://digitalcollections.nypl.org/items/510d47de-1848-a3d9-e040-e00a18064a99"
     ],
-    "hammer_and_pick": [],
-    "hammer_and_wrench": [
-        "http://digitalcollections.nypl.org/items/510d47d9-acbf-a3d9-e040-e00a18064a99"    
+    "🎽": [
+        "http://digitalcollections.nypl.org/items/510d47dc-48d0-a3d9-e040-e00a18064a99"
     ],
-    "hamster":[
-        "http://digitalcollections.nypl.org/items/510d47d9-78a5-a3d9-e040-e00a18064a99"
+    "🎾": [
+        "http://digitalcollections.nypl.org/items/782f625e-0539-87c4-e040-e00a18061872"
     ],
-    "hand":[
-        "http://digitalcollections.nypl.org/items/5e05e730-1f96-0134-91ec-00505686a51c",
-        "http://digitalcollections.nypl.org/items/510d47e4-72a5-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-3649-a3d9-e040-e00a18064a99"
+    "🎿": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e288-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-070f-d471-e040-e00a180654d7"
     ],
-    "handbag":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c184-d471-e040-e00a180654d7"
+    "🏀": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-2840-d471-e040-e00a180654d7"
     ],
-    "hankey":[
-        "http://digitalcollections.nypl.org/items/510d47e0-8081-a3d9-e040-e00a18064a99"
+    "🏁": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-af71-d471-e040-e00a180654d7"
     ],
-    "hash": [],
-    "hatched_chick":[
-        "http://digitalcollections.nypl.org/items/510d47e3-235b-a3d9-e040-e00a18064a99"
+    "🏂": [],
+    "🏃": [
+        "http://digitalcollections.nypl.org/items/510d47de-7674-a3d9-e040-e00a18064a99"
     ],
-    "hatching_chick":[
-        "http://digitalcollections.nypl.org/items/510d47db-491d-a3d9-e040-e00a18064a99"
+    "🏄": [
+        "http://digitalcollections.nypl.org/items/510d47e3-dc4c-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/a29dbeab-a2f8-6c08-e040-e00a18063abd"
     ],
-    "headphones":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7be3-a3d9-e040-e00a18064a99"
+    "🏅": [],
+    "🏆": [
+        "http://digitalcollections.nypl.org/items/510d47de-058b-a3d9-e040-e00a18064a99"
     ],
-    "hear_no_evil":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c695-a3d9-e040-e00a18064a99"
-    ],
-    "heart":[
-        "http://digitalcollections.nypl.org/items/510d47db-c0bd-a3d9-e040-e00a18064a99"
-    ],
-    "heart_decoration":[
-        "http://digitalcollections.nypl.org/items/510d47df-e40e-a3d9-e040-e00a18064a99"
-    ],
-    "heart_eyes":[
-        "http://digitalcollections.nypl.org/items/510d47e3-649b-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-5cb5-a3d9-e040-e00a18064a99"
-    ],
-    "heart_eyes_cat":[
-        "http://digitalcollections.nypl.org/items/510d47de-ea0c-a3d9-e040-e00a18064a99"
-    ],
-    "heartbeat":[
-        "http://digitalcollections.nypl.org/items/510d47e1-08be-a3d9-e040-e00a18064a99"
-    ],
-    "heartpulse": [],
-    "hearts":[
-        "http://digitalcollections.nypl.org/items/510d47e3-253f-a3d9-e040-e00a18064a99"
-    ],
-    "heavy_check_mark": [
-        "http://digitalcollections.nypl.org/items/510d47da-5865-a3d9-e040-e00a18064a99"    
-    ],
-    "heavy_division_sign": [],
-    "heavy_dollar_sign": [],
-    "heavy_exclamation_mark": [],
-    "heavy_heart_exclamation_mark_ornament": [],
-    "heavy_minus_sign": [],
-    "heavy_multiplication_x": [],
-    "heavy_plus_sign":[
-        "http://digitalcollections.nypl.org/items/510d47e3-c58c-a3d9-e040-e00a18064a99"
-    ],
-    "helicopter":[
-        "http://digitalcollections.nypl.org/items/510d47da-94f2-a3d9-e040-e00a18064a99"
-    ],
-    "helmet_with_white_cross": [],
-    "herb":[
-        "http://digitalcollections.nypl.org/items/510d47dd-c5b0-a3d9-e040-e00a18064a99"
-    ],
-    "hibiscus":[
-        "http://digitalcollections.nypl.org/items/510d47dc-926e-a3d9-e040-e00a18064a99"
-    ],
-    "high_brightness": [],
-    "high_heel":[
-        "http://digitalcollections.nypl.org/items/893c0fe7-82ee-ad5f-e040-e00a18064278",
-        "http://digitalcollections.nypl.org/items/510d47e4-5132-a3d9-e040-e00a18064a99"
-    ],
-    "hocho":[
-        "http://digitalcollections.nypl.org/items/510d47de-38ab-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-d15e-a3d9-e040-e00a18064a99"
-    ],
-    "hole":[
-        "http://digitalcollections.nypl.org/items/510d47de-009c-a3d9-e040-e00a18064a99"
-    ],
-    "honey_pot":[
-        "http://digitalcollections.nypl.org/items/510d47e1-43ee-a3d9-e040-e00a18064a99"
-    ],
-    "honeybee": [],
-    "horse":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-944b-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47e4-7281-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-83b0-a3d9-e040-e00a18064a99"
-    ],
-    "horse_racing":[
+    "🏇": [
         "http://digitalcollections.nypl.org/items/510d47e2-daa7-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e2-d780-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e2-da83-a3d9-e040-e00a18064a99"
     ],
-    "hospital":[
-        "http://digitalcollections.nypl.org/items/510d47d9-cb7f-a3d9-e040-e00a18064a99"
+    "🏈": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-7e14-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-8e8d-d471-e040-e00a180654d7"
     ],
-    "hot_pepper":[
-        "http://digitalcollections.nypl.org/items/510d47df-f6d8-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-37d5-a3d9-e040-e00a18064a99"
+    "🏉": [
+        "http://digitalcollections.nypl.org/items/510d47da-792d-a3d9-e040-e00a18064a99"
     ],
-    "hotdog":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-86a3-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47df-3360-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e0-db21-a3d9-e040-e00a18064a99"
+    "🏊": [
+        "http://digitalcollections.nypl.org/items/510d47e4-68fa-a3d9-e040-e00a18064a99"
     ],
-    "hotel":[
-        "http://digitalcollections.nypl.org/items/a4958095-4506-074d-e040-e00a1806792c"
+    "🏋": [
+        "http://digitalcollections.nypl.org/items/510d47dc-9c1c-a3d9-e040-e00a18064a99"
     ],
-    "hotsprings":[
-        "http://digitalcollections.nypl.org/items/510d47da-5d28-a3d9-e040-e00a18064a99"
+    "🏌": [
+        "http://digitalcollections.nypl.org/items/510d47e0-fe61-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-4662-a3d9-e040-e00a18064a99"
     ],
-    "hourglass":[
-        "http://digitalcollections.nypl.org/items/510d47dd-f3eb-a3d9-e040-e00a18064a99"
+    "🏍": [
+        "http://digitalcollections.nypl.org/items/510d47e2-3c02-a3d9-e040-e00a18064a99"
     ],
-    "hourglass_flowing_sand":[
-        "http://digitalcollections.nypl.org/items/510d47de-32f7-a3d9-e040-e00a18064a99"
+    "🏎": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-1551-d471-e040-e00a180654d7"
     ],
-    "house": [
-        "http://digitalcollections.nypl.org/items/510d47d9-ae55-a3d9-e040-e00a18064a99"
+    "🏏": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c1cd-a3d9-e040-e00a18064a99"
     ],
-    "house_buildings":[
-        "http://digitalcollections.nypl.org/items/510d47e2-d03b-a3d9-e040-e00a18064a99"
+    "🏐": [
+        "http://digitalcollections.nypl.org/items/510d47e0-db34-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-bb8a-a3d9-e040-e00a18064a99"
     ],
-    "house_with_garden": [
-        "http://digitalcollections.nypl.org/items/510d47d9-ad70-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-adcc-a3d9-e040-e00a18064a99"    
+    "🏑": [
+        "http://digitalcollections.nypl.org/items/510d47da-6ab5-a3d9-e040-e00a18064a99"
     ],
-    "hugging_face":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-20ff-d471-e040-e00a180654d7"
-    ],
-    "hushed": [
-        "http://digitalcollections.nypl.org/items/510d47e2-f719-a3d9-e040-e00a18064a99"    
-    ],
-    "ice_cream":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-b580-d471-e040-e00a180654d7"
-    ],
-    "ice_hockey_stick_and_puck":[
+    "🏒": [
         "http://digitalcollections.nypl.org/items/7d20cdeb-e431-4a73-e040-e00a18060ccc"
     ],
-    "ice_skate":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-1673-d471-e040-e00a180654d7"
+    "🏓": [
+        "http://digitalcollections.nypl.org/items/7d20cdeb-e421-4a73-e040-e00a18060ccc",
+        "http://digitalcollections.nypl.org/items/510d47e4-4201-a3d9-e040-e00a18064a99"
     ],
-    "icecream":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-b580-d471-e040-e00a180654d7"
+    "🏔": [
+        "http://digitalcollections.nypl.org/items/510d47d9-9bdb-a3d9-e040-e00a18064a99"
     ],
-    "id": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-bcea-d471-e040-e00a180654d7"    
+    "🏕": [
+        "http://digitalcollections.nypl.org/items/510d47de-331d-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-d022-a3d9-e040-e00a18064a99"
     ],
-    "ideograph_advantage": [],
-    "imp":[
-        "http://digitalcollections.nypl.org/items/6012d410-82b9-0130-376c-58d385a7bbd0"
+    "🏖": [
+        "http://digitalcollections.nypl.org/items/510d47df-f731-a3d9-e040-e00a18064a99"
     ],
-    "inbox_tray": [],
-    "incoming_envelope":[
-        "http://digitalcollections.nypl.org/items/510d47e3-565c-a3d9-e040-e00a18064a99"
+    "🏗": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-cef1-d471-e040-e00a180654d7"
     ],
-    "information_desk_person":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e93e-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47dd-eb84-a3d9-e040-e00a18064a99"
+    "🏘": [
+        "http://digitalcollections.nypl.org/items/510d47e2-d03b-a3d9-e040-e00a18064a99"
     ],
-    "information_source":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-7bf1-d471-e040-e00a180654d7"
+    "🏙": [
+        "http://digitalcollections.nypl.org/items/510d47e1-4145-a3d9-e040-e00a18064a99"
     ],
-    "innocent":[
-        "http://digitalcollections.nypl.org/items/591ccad0-da38-0132-90f2-58d385a7b928"
+    "🏚": [
+        "http://digitalcollections.nypl.org/items/b4afdefd-4988-146a-e040-e00a180610a2"
     ],
-    "interrobang": [],
-    "iphone":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-bb79-d471-e040-e00a180654d7"
+    "🏛": [
+        "http://digitalcollections.nypl.org/items/510d47e0-a9ee-a3d9-e040-e00a18064a99"
     ],
-    "it": [],
-    "izakaya_lantern":[
-        "http://digitalcollections.nypl.org/items/c261ef12-e4a4-3577-e040-e00a18067776"
+    "🏜": [
+        "http://digitalcollections.nypl.org/items/510d47da-35ae-a3d9-e040-e00a18064a99"
     ],
-    "jack_o_lantern":[
-        "http://digitalcollections.nypl.org/items/b16926af-3fe3-6b2f-e040-e00a1806531a"
+    "🏝": [
+        "http://digitalcollections.nypl.org/items/510d47d9-9ae5-a3d9-e040-e00a18064a99"
     ],
-    "japan":[
-        "http://digitalcollections.nypl.org/items/510d47e4-08e1-a3d9-e040-e00a18064a99"
-    ],
-    "japanese_castle":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c584-a3d9-e040-e00a18064a99"
-    ],
-    "japanese_goblin":[
-        "http://digitalcollections.nypl.org/items/510d47dc-885e-a3d9-e040-e00a18064a99"
-    ],
-    "japanese_ogre":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-72b3-d471-e040-e00a180654d7"
-    ],
-    "jeans":[
-        "http://digitalcollections.nypl.org/items/b31f5d33-7a2c-17da-e040-e00a18062482"
-    ],
-    "joy":[
-        "http://digitalcollections.nypl.org/items/510d47df-f1d0-a3d9-e040-e00a18064a99"
-    ],
-    "joy_cat":[
-        "http://digitalcollections.nypl.org/items/510d47da-9b89-a3d9-e040-e00a18064a99"
-    ],
-    "joystick": [],
-    "jp": [],
-    "kaaba":[
-        "http://digitalcollections.nypl.org/items/510d47dc-47ad-a3d9-e040-e00a18064a99"
-    ],
-    "key":[
-        "http://digitalcollections.nypl.org/items/510d47df-a19d-a3d9-e040-e00a18064a99"
-    ],
-    "keyboard": [],
-    "keycap_star": [],
-    "keycap_ten":[
-        "http://digitalcollections.nypl.org/items/510d47e3-972c-a3d9-e040-e00a18064a99"
-    ],
-    "kimono":[
-        "http://digitalcollections.nypl.org/items/510d47e4-0002-a3d9-e040-e00a18064a99"
-    ],
-    "kiss":[
-        "http://digitalcollections.nypl.org/items/893c0fe7-8211-ad5f-e040-e00a18064278",
-        "http://digitalcollections.nypl.org/items/510d47e2-e5f6-a3d9-e040-e00a18064a99"
-    ],
-    "kissing":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4eb3-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/bc76a6fe-2dea-6f87-e040-e00a18067e76"
-    ],
-    "kissing_cat":[
-        "http://digitalcollections.nypl.org/items/68a46690-e04c-0131-ddd9-58d385a7bbd0"
-    ],
-    "kissing_closed_eyes": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-f9f3-d471-e040-e00a180654d7"
-    ],
-    "kissing_heart":[
-        "http://digitalcollections.nypl.org/items/023648b0-bb8c-0132-bcbd-58d385a7bbd0"
-    ],
-    "kissing_smiling_eyes": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-9ef4-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/b31f5d33-816b-17da-e040-e00a18062482",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-8ca7-d471-e040-e00a180654d7"
-    ],
-    "knife": [],
-    "knife_fork_plate":[
-        "http://digitalcollections.nypl.org/items/510d47da-d7fa-a3d9-e040-e00a18064a99"
-    ],
-    "koala":[
-        "http://digitalcollections.nypl.org/items/aeb794f0-62ec-9d00-e040-e00a180658fd",
-        "http://digitalcollections.nypl.org/items/510d47da-bb6e-a3d9-e040-e00a18064a99"
-    ],
-    "koko": [],
-    "kr": [],
-    "label":[
-        "http://digitalcollections.nypl.org/items/510d47e3-c590-a3d9-e040-e00a18064a99"
-    ],
-    "lantern": [],
-    "large_blue_circle":[
-        "http://digitalcollections.nypl.org/items/510d47e2-e24c-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-a00f-a3d9-e040-e00a18064a99"
-    ],
-    "large_blue_diamond":[
-        "http://digitalcollections.nypl.org/items/510d47e2-45d2-a3d9-e040-e00a18064a99"
-    ],
-    "large_orange_diamond":[
-        "http://digitalcollections.nypl.org/items/510d47dc-41f4-a3d9-e040-e00a18064a99"
-    ],
-    "last_quarter_moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
-    ],
-    "last_quarter_moon_with_face":[
-        "http://digitalcollections.nypl.org/items/96c1c508-1f08-dfa7-e040-e00a1806799d"
-    ],
-    "latin_cross": [],
-    "laughing":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-a2c4-d471-e040-e00a180654d7"
-    ],
-    "leaves":[
-        "http://digitalcollections.nypl.org/items/510d47e4-1050-a3d9-e040-e00a18064a99"
-    ],
-    "ledger":[
-        "http://digitalcollections.nypl.org/items/28ba45d0-ba67-0130-4c75-58d385a7b928"
-    ],
-    "left_luggage": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-9a8e-d471-e040-e00a180654d7"    
-    ],
-    "left_right_arrow": [],
-    "left_speech_bubble": [],
-    "leftwards_arrow_with_hook": [],
-    "lemon":[
-        "http://digitalcollections.nypl.org/items/510d47dc-9395-a3d9-e040-e00a18064a99"
-    ],
-    "leo":[
-        "http://digitalcollections.nypl.org/items/510d47e4-675f-a3d9-e040-e00a18064a99"
-    ],
-    "leopard":[
-        "http://digitalcollections.nypl.org/items/510d47da-99ee-a3d9-e040-e00a18064a99"
-    ],
-    "level_slider": [],
-    "libra":[
-        "http://digitalcollections.nypl.org/items/510d47e4-676b-a3d9-e040-e00a18064a99"
-    ],
-    "light_rail": [],
-    "lightning":[
-        "http://digitalcollections.nypl.org/items/510d47e0-f95f-a3d9-e040-e00a18064a99"
-    ],
-    "lightning_cloud": [],
-    "link":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b6e5-a3d9-e040-e00a18064a99"
-    ],
-    "linked_paperclips": [
-        "http://digitalcollections.nypl.org/items/510d47dd-e20f-a3d9-e040-e00a18064a99"    
-    ],
-    "lion_face":[
-        "http://digitalcollections.nypl.org/items/510d47da-9eed-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-24ea-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/7cfd6b6c-0e7f-8833-e040-e00a18067633",
-        "http://digitalcollections.nypl.org/items/78315148-f07f-8a8d-e040-e00a18064798",
-        "http://digitalcollections.nypl.org/items/91950f24-c3d9-a7e0-e040-e00a18062992",
-        "http://digitalcollections.nypl.org/items/510d47da-3e49-a3d9-e040-e00a18064a99"
-    ],
-    "lips":[
-        "http://digitalcollections.nypl.org/items/893c0fe7-8211-ad5f-e040-e00a18064278"
-    ],
-    "lipstick": [
-        "http://digitalcollections.nypl.org/items/510d47e3-fa22-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/40a5a460-0857-0131-e369-58d385a7b928"
-    ],
-    "lock":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7a85-a3d9-e040-e00a18064a99"
-    ],
-    "lock_with_ink_pen": [],
-    "lollipop": [],
-    "loop":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-f9cc-d471-e040-e00a180654d7"
-    ],
-    "loud_sound": [],
-    "loudspeaker": [],
-    "love_hotel":[
-        "http://digitalcollections.nypl.org/items/510d47d9-cb49-a3d9-e040-e00a18064a99"
-    ],
-    "love_letter":[
-        "http://digitalcollections.nypl.org/items/510d47db-df24-a3d9-e040-e00a18064a99"
-    ],
-    "low_brightness": [],
-    "lower_left_ballpoint_pen": [],
-    "lower_left_crayon": [],
-    "lower_left_fountain_pen": [],
-    "lower_left_paintbrush":[
-        "http://digitalcollections.nypl.org/items/510d47e4-7ab5-a3d9-e040-e00a18064a99"
-    ],
-    "m":[
-        "http://digitalcollections.nypl.org/items/510d47db-b6cd-a3d9-e040-e00a18064a99"
-    ],
-    "mag": [],
-    "mag_right": [],
-    "mahjong": [],
-    "mailbox":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b802-a3d9-e040-e00a18064a99"
-    ],
-    "mailbox_closed":[
-        "http://digitalcollections.nypl.org/items/86c7de60-08a5-0133-21a7-58d385a7bbd0"
-    ],
-    "mailbox_with_mail": [
-        "http://digitalcollections.nypl.org/items/510d47e3-6184-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-3d34-a3d9-e040-e00a18064a99"
-    ],
-    "mailbox_with_no_mail": [
-        "http://digitalcollections.nypl.org/items/510d47dd-8634-a3d9-e040-e00a18064a99"    
-    ],
-    "man":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c367-a3d9-e040-e00a18064a99"
-    ],
-    "man-heart-man": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9627-a3d9-e040-e00a18064a99"    
-    ],
-    "man-kiss-man": [
-        "http://digitalcollections.nypl.org/items/510d47e3-b5a4-a3d9-e040-e00a18064a99"
-    ],
-    "man-man-boy": [
-        "http://digitalcollections.nypl.org/items/510d47e0-db9b-a3d9-e040-e00a18064a99"    
-    ],
-    "man-man-boy-boy": [
-        "http://digitalcollections.nypl.org/items/510d47e0-eb6e-a3d9-e040-e00a18064a99"
-    ],
-    "man-man-girl": [],
-    "man-man-girl-boy": [],
-    "man-man-girl-girl": [],
-    "man-woman-boy": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-b7b0-d471-e040-e00a180654d7"    
-    ],
-    "man-woman-boy-boy": [],
-    "man-woman-girl": [
-        "http://digitalcollections.nypl.org/items/510d47df-1f42-a3d9-e040-e00a18064a99"    
-    ],
-    "man-woman-girl-boy": [],
-    "man-woman-girl-girl": [
-        "http://digitalcollections.nypl.org/items/510d47df-950c-a3d9-e040-e00a18064a99"    
-    ],
-    "man_and_woman_holding_hands": [
-        "http://digitalcollections.nypl.org/items/286a7aa0-024b-0133-d968-58d385a7bbd0"    
-    ],
-    "man_in_business_suit_levitating":[
-        "http://digitalcollections.nypl.org/items/510d47da-4ed6-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/b5cfbf49-a5a0-7548-e040-e00a18060aef"
-    ],
-    "man_with_gua_pi_mao":[
-        "http://digitalcollections.nypl.org/items/510d47e1-20da-a3d9-e040-e00a18064a99"
-    ],
-    "man_with_turban":[
-        "http://digitalcollections.nypl.org/items/510d47d9-623b-a3d9-e040-e00a18064a99"
-    ],
-    "mans_shoe":[
-        "http://digitalcollections.nypl.org/items/510d47e1-32be-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-9b6e-a3d9-e040-e00a18064a99"
-    ],
-    "mantelpiece_clock": [],
-    "maple_leaf":[
-        "http://digitalcollections.nypl.org/items/510d47e0-0874-a3d9-e040-e00a18064a99"
-    ],
-    "mask":[
-        "http://digitalcollections.nypl.org/items/2d70eaa0-0439-0131-fd4f-58d385a7b928"
-    ],
-    "massage":[
-        "http://digitalcollections.nypl.org/items/510d47e4-5db2-a3d9-e040-e00a18064a99"
-    ],
-    "meat_on_bone":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e177-d471-e040-e00a180654d7"
-    ],
-    "medal":[
-        "http://digitalcollections.nypl.org/items/510d47e2-1950-a3d9-e040-e00a18064a99"
-    ],
-    "mega":[
-        "http://digitalcollections.nypl.org/items/510d47e0-eea9-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-22ec-a3d9-e040-e00a18064a99"
-    ],
-    "melon":[
-        "http://digitalcollections.nypl.org/items/510d47dc-7de3-a3d9-e040-e00a18064a99"
-    ],
-    "memo":[
-        "http://digitalcollections.nypl.org/items/510d47db-5169-a3d9-e040-e00a18064a99"
-    ],
-    "menorah_with_nine_branches":[
-        "http://digitalcollections.nypl.org/items/510d47de-1cc6-a3d9-e040-e00a18064a99"
-    ],
-    "mens": [],
-    "metro":[
-        "http://digitalcollections.nypl.org/items/510d47e1-062f-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-8ce3-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-8cdf-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/661b0b70-a456-0130-bf20-58d385a7bbd0"
-    ],
-    "microphone":[
-        "http://digitalcollections.nypl.org/items/a27ad31f-c170-9bd4-e040-e00a18067343",
-        "http://digitalcollections.nypl.org/items/9be9e150-5eb6-0131-0b36-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-9fdd-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/8caac9b0-d13f-0130-21ba-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/6e7d64e0-7df9-0130-1dbf-58d385a7bbd0"
-    ],
-    "microscope":[
-        "http://digitalcollections.nypl.org/items/510d47e2-47a4-a3d9-e040-e00a18064a99"
-    ],
-    "middle_finger": [],
-    "milky_way":[
-        "http://digitalcollections.nypl.org/items/510d47db-d3ea-a3d9-e040-e00a18064a99"
-    ],
-    "minibus":[
-        "http://digitalcollections.nypl.org/items/510d47db-b776-a3d9-e040-e00a18064a99"
-    ],
-    "minidisc": [],
-    "mobile_phone_off": [],
-    "money_mouth_face": [],
-    "money_with_wings": [],
-    "moneybag":[
-        "http://digitalcollections.nypl.org/items/510d47e2-331e-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/7456f4d0-bb89-0132-37ab-58d385a7bbd0"
-    ],
-    "monkey":[
-        "http://digitalcollections.nypl.org/items/510d47d9-6ce5-a3d9-e040-e00a18064a99"
-    ],
-    "monkey_face":[
-        "http://digitalcollections.nypl.org/items/510d47da-9dde-a3d9-e040-e00a18064a99"
-    ],
-    "monorail":[
-        "http://digitalcollections.nypl.org/items/917bb7f6-f58e-6224-e040-e00a180679cb"
-    ],
-    "moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
-    ],
-    "mortar_board":[
-        "http://digitalcollections.nypl.org/items/510d47e0-f03d-a3d9-e040-e00a18064a99"
-    ],
-    "mosque":[
-        "http://digitalcollections.nypl.org/items/510d47d9-5c6b-a3d9-e040-e00a18064a99"
-    ],
-    "mostly_sunny":[
-        "http://digitalcollections.nypl.org/items/b1e3b2f0-e051-0131-0cca-58d385a7b928"
-    ],
-    "motor_boat":[
-        "http://digitalcollections.nypl.org/items/510d47d9-bac2-a3d9-e040-e00a18064a99"
-    ],
-    "motorway":[
-        "http://digitalcollections.nypl.org/items/510d47d9-9dcb-a3d9-e040-e00a18064a99"
-    ],
-    "mount_fuji":[
-        "http://digitalcollections.nypl.org/items/c260bdb3-9b61-4552-e040-e00a18066d81"
-    ],
-    "mountain":[
-        "http://digitalcollections.nypl.org/items/510d47d9-3f32-a3d9-e040-e00a18064a99"
-    ],
-    "mountain_bicyclist":[
-        "http://digitalcollections.nypl.org/items/510d47da-cf66-a3d9-e040-e00a18064a99"
-    ],
-    "mountain_cableway":[
-        "http://digitalcollections.nypl.org/items/510d47e1-9230-a3d9-e040-e00a18064a99"
-    ],
-    "mountain_railway":[
-        "http://digitalcollections.nypl.org/items/510d47e1-8a0a-a3d9-e040-e00a18064a99"
-    ],
-    "mouse":[
-        "http://digitalcollections.nypl.org/items/510d47e3-236b-a3d9-e040-e00a18064a99"
-    ],
-    "mouse2":[
-        "http://digitalcollections.nypl.org/items/510d47da-9f15-a3d9-e040-e00a18064a99"
-    ],
-    "movie_camera":[
-        "http://digitalcollections.nypl.org/items/510d47da-930b-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47de-ab6c-a3d9-e040-e00a18064a99"
-    ],
-    "moyai":[
-        "http://digitalcollections.nypl.org/items/510d47e3-ad5d-a3d9-e040-e00a18064a99"
-    ],
-    "muscle":[
-        "http://digitalcollections.nypl.org/items/510d47e2-3048-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/1f93e200-32dc-0132-7cf5-58d385a7bbd0"
-    ],
-    "mushroom":[
-        "http://digitalcollections.nypl.org/items/510d47e2-dee0-a3d9-e040-e00a18064a99"
-    ],
-    "musical_keyboard":[
-        "http://digitalcollections.nypl.org/items/510d47d9-3cad-a3d9-e040-e00a18064a99"
-    ],
-    "musical_note": [
-        "http://digitalcollections.nypl.org/items/a50e602d-63d5-f9b6-e040-e00a180649c6"    
-    ],
-    "musical_score":[
-        "http://digitalcollections.nypl.org/items/510d47de-1848-a3d9-e040-e00a18064a99"
-    ],
-    "mute": [],
-    "nail_care":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-0461-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e3d7-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/04ca17e0-9abf-0132-7fe6-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/510d47e2-1db4-a3d9-e040-e00a18064a99"
-    ],
-    "name_badge": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ca06-d471-e040-e00a180654d7"    
-    ],
-    "national_park":[
+    "🏞": [
         "http://digitalcollections.nypl.org/items/510d47d9-3f40-a3d9-e040-e00a18064a99"
     ],
-    "necktie":[
-        "http://digitalcollections.nypl.org/items/510d47e1-0331-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e0-fd05-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e0-fd0e-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e0-fd04-a3d9-e040-e00a18064a99"
+    "🏟": [
+        "http://digitalcollections.nypl.org/items/510d47e4-58c2-a3d9-e040-e00a18064a99"
     ],
-    "negative_squared_cross_mark": [],
-    "nerd_face":[
-        "http://digitalcollections.nypl.org/items/ba309cea-95e2-4288-e040-e00a18066c61"
+    "🏠": [
+        "http://digitalcollections.nypl.org/items/510d47d9-ae55-a3d9-e040-e00a18064a99"
     ],
-    "neutral_face": [
-        "http://digitalcollections.nypl.org/items/510d47e2-f72f-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/d4087230-f215-0130-69b3-58d385a7b928"    
+    "🏡": [
+        "http://digitalcollections.nypl.org/items/510d47d9-ad70-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-adcc-a3d9-e040-e00a18064a99"
     ],
-    "new": [],
-    "new_moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
+    "🏢": [
+        "http://digitalcollections.nypl.org/items/bc3bede1-6a6a-cebb-e040-e00a18064596"
     ],
-    "new_moon_with_face":[
-        "http://digitalcollections.nypl.org/items/890277b9-4331-5552-e040-e00a18065ce4"
+    "🏣": [
+        "http://digitalcollections.nypl.org/items/c26315f5-f0cf-8706-e040-e00a1806153e"
     ],
-    "newspaper":[
-        "http://digitalcollections.nypl.org/items/510d47de-38fd-a3d9-e040-e00a18064a99"
+    "🏤": [],
+    "🏥": [
+        "http://digitalcollections.nypl.org/items/510d47d9-cb7f-a3d9-e040-e00a18064a99"
     ],
-    "ng": [],
-    "night_with_stars":[
-        "http://digitalcollections.nypl.org/items/510d47dd-a825-a3d9-e040-e00a18064a99"
+    "🏦": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-1e84-d471-e040-e00a180654d7"
     ],
-    "nine": [],
-    "no_bell":[
-        "http://digitalcollections.nypl.org/items/510d47e0-ab68-a3d9-e040-e00a18064a99"
+    "🏧": [
+        "http://digitalcollections.nypl.org/items/510d47e2-eb82-a3d9-e040-e00a18064a99"
     ],
-    "no_bicycles": [],
-    "no_entry":[
-        "http://digitalcollections.nypl.org/items/510d47da-d196-a3d9-e040-e00a18064a99"
+    "🏨": [
+        "http://digitalcollections.nypl.org/items/a4958095-4506-074d-e040-e00a1806792c"
     ],
-    "no_entry_sign": [],
-    "no_good":[
-        "http://digitalcollections.nypl.org/items/dd3071c0-0dfe-0133-97a8-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/5f614ec0-8b73-0131-8cb9-58d385a7b928"
+    "🏩": [
+        "http://digitalcollections.nypl.org/items/510d47d9-cb49-a3d9-e040-e00a18064a99"
     ],
-    "no_mobile_phones": [],
-    "no_mouth":[
-        "http://digitalcollections.nypl.org/items/510d47da-f3e9-a3d9-e040-e00a18064a99"
+    "🏪": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c03c-a3d9-e040-e00a18064a99"
     ],
-    "no_pedestrians": [],
-    "no_smoking":[
-        "http://digitalcollections.nypl.org/items/510d47e3-7831-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-435c-a3d9-e040-e00a18064a99"
+    "🏫": [
+        "http://digitalcollections.nypl.org/items/510d47e0-61b2-a3d9-e040-e00a18064a99"
     ],
-    "non-potable_water":[
-        "http://digitalcollections.nypl.org/items/af9c1ab0-e906-0131-1c10-3c075448cc4b"
+    "🏬": [
+        "http://digitalcollections.nypl.org/items/510d47e0-d334-a3d9-e040-e00a18064a99"
     ],
-    "nose":[
-        "http://digitalcollections.nypl.org/items/510d47e4-728d-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dc-8fcb-a3d9-e040-e00a18064a99"
+    "🏭": [
+        "http://digitalcollections.nypl.org/items/510d47de-075e-a3d9-e040-e00a18064a99"
     ],
-    "notebook":[
-        "http://digitalcollections.nypl.org/items/4f10fef0-e81a-0131-198c-58d385a7b928"
+    "🏮": [
+        "http://digitalcollections.nypl.org/items/c261ef12-e4a4-3577-e040-e00a18067776"
     ],
-    "notebook_with_decorative_cover":[
-        "http://digitalcollections.nypl.org/items/d9723ca0-57d4-0132-6ad4-58d385a7bbd0"
+    "🏯": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c584-a3d9-e040-e00a18064a99"
     ],
-    "notes": [
-        "http://digitalcollections.nypl.org/items/510d47e3-6dfa-a3d9-e040-e00a18064a99"    
+    "🏰": [
+        "http://digitalcollections.nypl.org/items/510d47e2-edd6-a3d9-e040-e00a18064a99"
     ],
-    "nut_and_bolt":[
-        "http://digitalcollections.nypl.org/items/510d47df-fa1b-a3d9-e040-e00a18064a99"
+    "🏳": [
+        "http://digitalcollections.nypl.org/items/510d47e0-f629-a3d9-e040-e00a18064a99"
     ],
-    "o": [],
-    "o2":[
-        "http://digitalcollections.nypl.org/items/510d47dc-42bb-a3d9-e040-e00a18064a99"
+    "🏴": [
+        "http://digitalcollections.nypl.org/items/510d47e1-23e3-a3d9-e040-e00a18064a99"
     ],
-    "ocean":[
-        "http://digitalcollections.nypl.org/items/510d47e0-cafa-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e4-7608-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e0-cb1f-a3d9-e040-e00a18064a99"
+    "🏵": [
+        "http://digitalcollections.nypl.org/items/510d47e1-1620-a3d9-e040-e00a18064a99"
     ],
-    "octopus":[
+    "🏷": [
+        "http://digitalcollections.nypl.org/items/510d47e3-c590-a3d9-e040-e00a18064a99"
+    ],
+    "🏸": [
+        "http://digitalcollections.nypl.org/items/7d20cdeb-e419-4a73-e040-e00a18060ccc"
+    ],
+    "🏹": [
+        "http://digitalcollections.nypl.org/items/510d47e3-0ef0-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e4-0c52-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-3d37-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-0946-a3d9-e040-e00a18064a99"
+    ],
+    "🏺": [
+        "http://digitalcollections.nypl.org/items/510d47e4-5fb6-a3d9-e040-e00a18064a99"
+    ],
+    "🏻": [],
+    "🏼": [],
+    "🏽": [],
+    "🏾": [],
+    "🏿": [],
+    "🐀": [
+        "http://digitalcollections.nypl.org/items/510d47d9-57bd-a3d9-e040-e00a18064a99"
+    ],
+    "🐁": [
+        "http://digitalcollections.nypl.org/items/510d47da-9f15-a3d9-e040-e00a18064a99"
+    ],
+    "🐂": [
+        "http://digitalcollections.nypl.org/items/510d47e1-419e-a3d9-e040-e00a18064a99"
+    ],
+    "🐃": [
+        "http://digitalcollections.nypl.org/items/4773e410-ff55-012f-5faa-58d385a7bc34"
+    ],
+    "🐄": [
+        "http://digitalcollections.nypl.org/items/510d47e1-418d-a3d9-e040-e00a18064a99"
+    ],
+    "🐅": [
+        "http://digitalcollections.nypl.org/items/510d47e0-cfcb-a3d9-e040-e00a18064a99"
+    ],
+    "🐆": [
+        "http://digitalcollections.nypl.org/items/510d47da-99ee-a3d9-e040-e00a18064a99"
+    ],
+    "🐇": [
+        "http://digitalcollections.nypl.org/items/510d47da-9c08-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/8c8c1916-8b75-426c-e040-e00a180650bb"
+    ],
+    "🐈": [
+        "http://digitalcollections.nypl.org/items/36735660-e04c-0131-c3ef-58d385a7bbd0"
+    ],
+    "🐉": [
+        "http://digitalcollections.nypl.org/items/510d47db-58dc-a3d9-e040-e00a18064a99"
+    ],
+    "🐊": [
+        "http://digitalcollections.nypl.org/items/510d47da-9e3a-a3d9-e040-e00a18064a99"
+    ],
+    "🐋": [
+        "http://digitalcollections.nypl.org/items/510d47e0-d034-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/8bbf1c8a-57a0-1c76-e040-e00a1806015b",
+        "http://digitalcollections.nypl.org/items/510d47db-d677-a3d9-e040-e00a18064a99"
+    ],
+    "🐌": [
+        "http://digitalcollections.nypl.org/items/510d47e3-c0e8-a3d9-e040-e00a18064a99"
+    ],
+    "🐍": [
+        "http://digitalcollections.nypl.org/items/510d47e1-1e18-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-13a2-d471-e040-e00a180654d7"
+    ],
+    "🐎": [
+        "http://digitalcollections.nypl.org/items/510d47e2-1af8-a3d9-e040-e00a18064a99"
+    ],
+    "🐏": [
+        "http://digitalcollections.nypl.org/items/510d47e2-d22f-a3d9-e040-e00a18064a99"
+    ],
+    "🐐": [
+        "http://digitalcollections.nypl.org/items/510d47e2-d4a4-a3d9-e040-e00a18064a99"
+    ],
+    "🐑": [
+        "http://digitalcollections.nypl.org/items/510d47e0-cf58-a3d9-e040-e00a18064a99"
+    ],
+    "🐒": [
+        "http://digitalcollections.nypl.org/items/510d47d9-6ce5-a3d9-e040-e00a18064a99"
+    ],
+    "🐓": [
+        "http://digitalcollections.nypl.org/items/a4958095-4644-074d-e040-e00a1806792c",
+        "http://digitalcollections.nypl.org/items/510d47e3-7872-a3d9-e040-e00a18064a99"
+    ],
+    "🐔": [
+        "http://digitalcollections.nypl.org/items/510d47e2-d4bc-a3d9-e040-e00a18064a99"
+    ],
+    "🐕": [
+        "http://digitalcollections.nypl.org/items/510d47dd-bd98-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-9277-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-3c8a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/b153a2d9-9cbc-2146-e040-e00a18062823"
+    ],
+    "🐖": [
+        "http://digitalcollections.nypl.org/items/510d47da-9da0-a3d9-e040-e00a18064a99"
+    ],
+    "🐗": [
+        "http://digitalcollections.nypl.org/items/510d47da-9d7e-a3d9-e040-e00a18064a99"
+    ],
+    "🐘": [
+        "http://digitalcollections.nypl.org/items/510d47e1-42d8-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-bbec-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-24d6-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-6d38-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-99dc-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-9ac3-a3d9-e040-e00a18064a99"
+    ],
+    "🐙": [
         "http://digitalcollections.nypl.org/items/7d20c47c-23fe-d7f9-e040-e00a18060c58",
         "http://digitalcollections.nypl.org/items/510d47e4-0fd7-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47da-a1a5-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47da-9fa9-a3d9-e040-e00a18064a99"
     ],
-    "oden": [],
-    "office":[
-        "http://digitalcollections.nypl.org/items/bc3bede1-6a6a-cebb-e040-e00a18064596"
+    "🐚": [
+        "http://digitalcollections.nypl.org/items/510d47db-b63a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-cc13-a3d9-e040-e00a18064a99"
     ],
-    "oil_drum":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b645-a3d9-e040-e00a18064a99"
+    "🐛": [
+        "http://digitalcollections.nypl.org/items/510d47d9-79d0-a3d9-e040-e00a18064a99"
     ],
-    "ok": [],
-    "ok_hand":[
-        "http://digitalcollections.nypl.org/items/510d47d9-4b8b-a3d9-e040-e00a18064a99"
+    "🐜": [
+        "http://digitalcollections.nypl.org/items/510d47e1-26a2-a3d9-e040-e00a18064a99"
     ],
-    "ok_woman":[
-        "http://digitalcollections.nypl.org/items/895df880-1e95-0133-4698-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/991bd460-9cbc-0131-8aed-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/148fc990-7de4-0130-f59a-58d385a7b928"
+    "🐝": [
+        "http://digitalcollections.nypl.org/items/510d47e2-e5cc-a3d9-e040-e00a18064a99"
     ],
-    "old_key":[
-        "http://digitalcollections.nypl.org/items/510d47e3-2549-a3d9-e040-e00a18064a99"
+    "🐞": [
+        "http://digitalcollections.nypl.org/items/510d47e1-26d8-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-2b28-a3d9-e040-e00a18064a99"
     ],
-    "older_man":[
-        "http://digitalcollections.nypl.org/items/510d47e4-72a3-a3d9-e040-e00a18064a99"
+    "🐟": [
+        "http://digitalcollections.nypl.org/items/510d47da-66c7-a3d9-e040-e00a18064a99"
     ],
-    "older_woman":[
-        "http://digitalcollections.nypl.org/items/510d47e3-d870-a3d9-e040-e00a18064a99"
+    "🐠": [
+        "http://digitalcollections.nypl.org/items/7d20c47c-2404-d7f9-e040-e00a18060c58"
     ],
-    "om_symbol": [],
-    "on": [],
-    "oncoming_automobile": [
-        "http://digitalcollections.nypl.org/items/6f02b7d0-ea71-0131-8e9f-58d385a7bbd0"    
+    "🐡": [
+        "http://digitalcollections.nypl.org/items/510d47e3-3791-a3d9-e040-e00a18064a99"
     ],
-    "oncoming_bus": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-a28c-d471-e040-e00a180654d7"    
+    "🐢": [
+        "http://digitalcollections.nypl.org/items/510d47e1-08d7-a3d9-e040-e00a18064a99"
     ],
-    "oncoming_police_car": [],
-    "oncoming_taxi": [
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-56b6-f55a-e040-e00a18062565"    
+    "🐣": [
+        "http://digitalcollections.nypl.org/items/510d47db-491d-a3d9-e040-e00a18064a99"
     ],
-    "one": [],
-    "open_book": [
-        "http://digitalcollections.nypl.org/items/510d47db-c679-a3d9-e040-e00a18064a99"
+    "🐤": [
+        "http://digitalcollections.nypl.org/items/510d47e3-4fcd-a3d9-e040-e00a18064a99"
     ],
-    "open_file_folder": [],
-    "open_hands": [
-        "http://digitalcollections.nypl.org/items/5e66b3e9-2620-d471-e040-e00a180654d7"    
+    "🐥": [
+        "http://digitalcollections.nypl.org/items/510d47e3-235b-a3d9-e040-e00a18064a99"
     ],
-    "open_mouth":[
-        "http://digitalcollections.nypl.org/items/aa16d2ae-75c7-3443-e040-e00a18067692",
-        "http://digitalcollections.nypl.org/items/8bfbd237-2d0f-aed1-e040-e00a1806680b"
+    "🐦": [
+        "http://digitalcollections.nypl.org/items/510d47e3-588b-a3d9-e040-e00a18064a99"
     ],
-    "ophiuchus":[
-        "http://digitalcollections.nypl.org/items/510d47dc-8dc1-a3d9-e040-e00a18064a99"
+    "🐧": [
+        "http://digitalcollections.nypl.org/items/510d47e3-20bb-a3d9-e040-e00a18064a99"
     ],
-    "orange_book":[
-        "http://digitalcollections.nypl.org/items/510d47dc-4031-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/54011580-5c94-0132-2f7a-58d385a7bbd0"
+    "🐨": [
+        "http://digitalcollections.nypl.org/items/aeb794f0-62ec-9d00-e040-e00a180658fd",
+        "http://digitalcollections.nypl.org/items/510d47da-bb6e-a3d9-e040-e00a18064a99"
     ],
-    "orthodox_cross": [],
-    "outbox_tray": [],
-    "ox":[
-        "http://digitalcollections.nypl.org/items/510d47e1-419e-a3d9-e040-e00a18064a99"
+    "🐩": [
+        "http://digitalcollections.nypl.org/items/510d47e2-2051-a3d9-e040-e00a18064a99"
     ],
-    "package":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b7da-a3d9-e040-e00a18064a99"
+    "🐪": [
+        "http://digitalcollections.nypl.org/items/510d47d9-52b6-a3d9-e040-e00a18064a99"
     ],
-    "page_facing_up": [
-        "http://digitalcollections.nypl.org/items/510d47df-d584-a3d9-e040-e00a18064a99"    
+    "🐫": [
+        "http://digitalcollections.nypl.org/items/510d47e1-43ec-a3d9-e040-e00a18064a99"
     ],
-    "page_with_curl":[
-        "http://digitalcollections.nypl.org/items/510d47d9-857a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/893c0fe7-8275-ad5f-e040-e00a18064278"
+    "🐬": [
+        "http://digitalcollections.nypl.org/items/510d47e3-2b0c-a3d9-e040-e00a18064a99"
     ],
-    "pager": [],
-    "palm_tree":[
-        "http://digitalcollections.nypl.org/items/510d47dc-8dc6-a3d9-e040-e00a18064a99"
+    "🐭": [
+        "http://digitalcollections.nypl.org/items/510d47e3-236b-a3d9-e040-e00a18064a99"
     ],
-    "panda_face":[
+    "🐮": [
+        "http://digitalcollections.nypl.org/items/b4238231-43b4-56ba-e040-e00a18066127"
+    ],
+    "🐯": [
+        "http://digitalcollections.nypl.org/items/7cfd6b6c-0e69-8833-e040-e00a18067633"
+    ],
+    "🐰": [
+        "http://digitalcollections.nypl.org/items/510d47de-72ea-a3d9-e040-e00a18064a99"
+    ],
+    "🐱": [
+        "http://digitalcollections.nypl.org/items/510d47de-6c14-a3d9-e040-e00a18064a99"
+    ],
+    "🐲": [
+        "http://digitalcollections.nypl.org/items/510d47e3-75f4-a3d9-e040-e00a18064a99"
+    ],
+    "🐳": [
+        "http://digitalcollections.nypl.org/items/510d47db-d768-a3d9-e040-e00a18064a99"
+    ],
+    "🐴": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-944b-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47e4-7281-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-83b0-a3d9-e040-e00a18064a99"
+    ],
+    "🐵": [
+        "http://digitalcollections.nypl.org/items/510d47da-9dde-a3d9-e040-e00a18064a99"
+    ],
+    "🐶": [
+        "http://digitalcollections.nypl.org/items/510d47e1-43b1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-05a8-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-c980-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-20e7-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5da15340-964a-0130-1b3f-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/53460140-e04c-0131-32c5-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47db-c4d3-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/c3903dcb-c932-6201-e040-e00a180642e6",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c083-d471-e040-e00a180654d7"
+    ],
+    "🐷": [
+        "http://digitalcollections.nypl.org/items/13f6df60-f6ce-0130-6cc6-58d385a7bbd0"
+    ],
+    "🐸": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9abe-a3d9-e040-e00a18064a99"
+    ],
+    "🐹": [
+        "http://digitalcollections.nypl.org/items/510d47d9-78a5-a3d9-e040-e00a18064a99"
+    ],
+    "🐺": [
+        "http://digitalcollections.nypl.org/items/510d47da-bc6f-a3d9-e040-e00a18064a99"
+    ],
+    "🐻": [
+        "http://digitalcollections.nypl.org/items/78309df1-0fff-23cc-e040-e00a180647e6",
+        "http://digitalcollections.nypl.org/items/510d47d9-6b06-a3d9-e040-e00a18064a99"
+    ],
+    "🐼": [
         "http://digitalcollections.nypl.org/items/5e66b3e9-14e6-d471-e040-e00a180654d7",
         "http://digitalcollections.nypl.org/items/5e66b3e8-aa8b-d471-e040-e00a180654d7",
         "http://digitalcollections.nypl.org/items/510d47e1-1244-a3d9-e040-e00a18064a99"
     ],
-    "paperclip":[
-        "http://digitalcollections.nypl.org/items/510d47dd-e20f-a3d9-e040-e00a18064a99"
-    ],
-    "parking":[
-        "http://digitalcollections.nypl.org/items/6b26eaac-2ba8-1da7-e040-e00a18062258"
-    ],
-    "part_alternation_mark": [],
-    "partly_sunny":[
-        "http://digitalcollections.nypl.org/items/510d47e1-a562-a3d9-e040-e00a18064a99"
-    ],
-    "partly_sunny_rain": [],
-    "passenger_ship":[
-        "http://digitalcollections.nypl.org/items/510d47db-7e75-a3d9-e040-e00a18064a99"
-    ],
-    "passport_control": [],
-    "paw_prints": [],
-    "peace_symbol": [],
-    "peach":[
-        "http://digitalcollections.nypl.org/items/510d47dd-e29c-a3d9-e040-e00a18064a99"
-    ],
-    "pear":[
-        "http://digitalcollections.nypl.org/items/510d47dd-d91d-a3d9-e040-e00a18064a99"
-    ],
-    "pencil": [],
-    "pencil2":[
-        "http://digitalcollections.nypl.org/items/40f7c3b0-7a59-0132-6cf1-58d385a7b928"
-    ],
-    "penguin":[
-        "http://digitalcollections.nypl.org/items/510d47e3-20bb-a3d9-e040-e00a18064a99"
-    ],
-    "pensive": [
-        "http://digitalcollections.nypl.org/items/510d47e3-7253-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/65234070-a456-0130-bd40-58d385a7bbd0"    
-    ],
-    "performing_arts":[
-        "http://digitalcollections.nypl.org/items/510d47e4-1a23-a3d9-e040-e00a18064a99"
-    ],
-    "persevere": [
-        "http://digitalcollections.nypl.org/items/5e66b3e9-217b-d471-e040-e00a180654d7"    
-    ],
-    "person_frowning":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a83a-a3d9-e040-e00a18064a99"
-    ],
-    "person_with_ball":[
-        "http://digitalcollections.nypl.org/items/510d47d9-bbdd-a3d9-e040-e00a18064a99"
-    ],
-    "person_with_blond_hair":[
-        "http://digitalcollections.nypl.org/items/510d47e4-06ae-a3d9-e040-e00a18064a99"
-    ],
-    "person_with_pouting_face": [],
-    "phone":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b17d-a3d9-e040-e00a18064a99"
-    ],
-    "pick": [
-        "http://digitalcollections.nypl.org/items/510d47dd-e4a0-a3d9-e040-e00a18064a99"    
-    ],
-    "pig":[
-        "http://digitalcollections.nypl.org/items/13f6df60-f6ce-0130-6cc6-58d385a7bbd0"
-    ],
-    "pig2":[
-        "http://digitalcollections.nypl.org/items/510d47da-9da0-a3d9-e040-e00a18064a99"
-    ],
-    "pig_nose":[
+    "🐽": [
         "http://digitalcollections.nypl.org/items/510d47e1-126a-a3d9-e040-e00a18064a99"
     ],
-    "pill":[
-        "http://digitalcollections.nypl.org/items/510d47de-3aab-a3d9-e040-e00a18064a99"
+    "🐾": [
+        "http://digitalcollections.nypl.org/items/510d47e1-3255-a3d9-e040-e00a18064a99"
     ],
-    "pineapple":[
-        "http://digitalcollections.nypl.org/items/510d47dd-c3f0-a3d9-e040-e00a18064a99"
+    "🐿": [
+        "http://digitalcollections.nypl.org/items/510d47e1-41c8-a3d9-e040-e00a18064a99"
     ],
-    "pisces":[
-        "http://digitalcollections.nypl.org/items/510d47e4-702d-a3d9-e040-e00a18064a99"
+    "👀": [
+        "http://digitalcollections.nypl.org/items/23e7a6b0-2fd0-0133-6064-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/99bdb5d2-c87c-c064-e040-e00a180650d2"
     ],
-    "pizza":[
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-555e-f55a-e040-e00a18062565",
-        "http://digitalcollections.nypl.org/items/ae2f51ec-bfc7-66c6-e040-e00a18066cf3",
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-5876-f55a-e040-e00a18062565"
+    "👁": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-6c2e-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-27b1-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ebf2-d471-e040-e00a180654d7"
     ],
-    "place_of_worship": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-84db-d471-e040-e00a180654d7"    
+    "👂": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7291-a3d9-e040-e00a18064a99"
     ],
-    "point_down": [],
-    "point_left": [],
-    "point_right":[
+    "👃": [
+        "http://digitalcollections.nypl.org/items/510d47e4-728d-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dc-8fcb-a3d9-e040-e00a18064a99"
+    ],
+    "👄": [
+        "http://digitalcollections.nypl.org/items/893c0fe7-8211-ad5f-e040-e00a18064278"
+    ],
+    "👅": [
+        "http://digitalcollections.nypl.org/items/510d47e4-593c-a3d9-e040-e00a18064a99"
+    ],
+    "👆": [],
+    "👇": [],
+    "👈": [],
+    "👉": [
         "http://digitalcollections.nypl.org/items/b48cc5d3-f271-175e-e040-e00a180651cd"
     ],
-    "point_up":[
-        "http://digitalcollections.nypl.org/items/510d47e4-1345-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/d47ffc10-dba5-0132-02b5-58d385a7b928"
+    "👊": [
+        "http://digitalcollections.nypl.org/items/510d47d9-bd29-a3d9-e040-e00a18064a99"
     ],
-    "point_up_2": [],
-    "police_car": [],
-    "poodle":[
-        "http://digitalcollections.nypl.org/items/510d47e2-2051-a3d9-e040-e00a18064a99"
+    "👋": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ac5a-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/477e5930-a0df-0132-2fb3-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/510d47df-f9fb-a3d9-e040-e00a18064a99"
     ],
-    "poop": [
-        "http://digitalcollections.nypl.org/items/510d47e0-8081-a3d9-e040-e00a18064a99"
+    "👌": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4b8b-a3d9-e040-e00a18064a99"
     ],
-    "popcorn":[
-        "http://digitalcollections.nypl.org/items/510d47dd-9e59-a3d9-e040-e00a18064a99"
+    "👍": [
+        "http://digitalcollections.nypl.org/items/b31f5d33-7f5a-17da-e040-e00a18062482",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-bad8-d471-e040-e00a180654d7"
     ],
-    "post_office": [
-        "http://digitalcollections.nypl.org/items/c26315f5-f0cf-8706-e040-e00a1806153e"    
+    "👎": [],
+    "👏": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-8869-d471-e040-e00a180654d7"
     ],
-    "postal_horn":[
-        "http://digitalcollections.nypl.org/items/a4958095-46e9-074d-e040-e00a1806792c"
+    "👐": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-2620-d471-e040-e00a180654d7"
     ],
-    "postbox":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b829-a3d9-e040-e00a18064a99"
+    "👑": [
+        "http://digitalcollections.nypl.org/items/510d47de-5aa3-a3d9-e040-e00a18064a99"
     ],
-    "potable_water":[
-        "http://digitalcollections.nypl.org/items/ae7bb9f5-4548-5a5d-e040-e00a1806317f"
+    "👒": [
+        "http://digitalcollections.nypl.org/items/510d47e1-2239-a3d9-e040-e00a18064a99"
     ],
-    "pouch":[
+    "👓": [
+        "http://digitalcollections.nypl.org/items/510d47d9-be15-a3d9-e040-e00a18064a99"
+    ],
+    "👔": [
+        "http://digitalcollections.nypl.org/items/510d47e1-0331-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e0-fd05-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e0-fd0e-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e0-fd04-a3d9-e040-e00a18064a99"
+    ],
+    "👕": [
+        "http://digitalcollections.nypl.org/items/c17b57e0-2b34-0134-7850-00505686a51c",
+        "http://digitalcollections.nypl.org/items/510d47e1-1e78-a3d9-e040-e00a18064a99"
+    ],
+    "👖": [
+        "http://digitalcollections.nypl.org/items/b31f5d33-7a2c-17da-e040-e00a18062482"
+    ],
+    "👗": [
+        "http://digitalcollections.nypl.org/items/8af99501-8288-161c-e040-e00a18064530"
+    ],
+    "👘": [
+        "http://digitalcollections.nypl.org/items/510d47e4-0002-a3d9-e040-e00a18064a99"
+    ],
+    "👙": [
+        "http://digitalcollections.nypl.org/items/8d7d24d3-d51d-f0f2-e040-e00a18065a91",
+        "http://digitalcollections.nypl.org/items/510d47e2-c063-a3d9-e040-e00a18064a99"
+    ],
+    "👚": [
+        "http://digitalcollections.nypl.org/items/ed653680-a8d7-0132-2d6c-58d385a7b928"
+    ],
+    "👛": [
+        "http://digitalcollections.nypl.org/items/96d3c1ce-0b21-c226-e040-e00a1806422e"
+    ],
+    "👜": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c184-d471-e040-e00a180654d7"
+    ],
+    "👝": [
         "http://digitalcollections.nypl.org/items/510d47d9-b22b-a3d9-e040-e00a18064a99"
     ],
-    "poultry_leg":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6485-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-bfe5-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-eea7-d471-e040-e00a180654d7"
+    "👞": [
+        "http://digitalcollections.nypl.org/items/510d47e1-32be-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-9b6e-a3d9-e040-e00a18064a99"
     ],
-    "pound": [],
-    "pouting_cat":[
-        "http://digitalcollections.nypl.org/items/510d47de-6c0a-a3d9-e040-e00a18064a99"
+    "👟": [
+        "http://digitalcollections.nypl.org/items/510d47da-d231-a3d9-e040-e00a18064a99"
     ],
-    "pray":[
-        "http://digitalcollections.nypl.org/items/510d47da-e4b4-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/72c56f40-f5fd-012f-768d-58d385a7bbd0"
+    "👠": [
+        "http://digitalcollections.nypl.org/items/893c0fe7-82ee-ad5f-e040-e00a18064278",
+        "http://digitalcollections.nypl.org/items/510d47e4-5132-a3d9-e040-e00a18064a99"
     ],
-    "prayer_beads":[
-        "http://digitalcollections.nypl.org/items/510d47e1-17f8-a3d9-e040-e00a18064a99"
+    "👡": [
+        "http://digitalcollections.nypl.org/items/510d47da-6eae-a3d9-e040-e00a18064a99"
     ],
-    "princess":[
+    "👢": [
+        "http://digitalcollections.nypl.org/items/510d47e1-32d2-a3d9-e040-e00a18064a99"
+    ],
+    "👣": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-17cc-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-17cc-d471-e040-e00a180654d7"
+    ],
+    "👤": [
+        "http://digitalcollections.nypl.org/items/510d47de-0847-a3d9-e040-e00a18064a99"
+    ],
+    "👥": [
+        "http://digitalcollections.nypl.org/items/510d47db-b6d2-a3d9-e040-e00a18064a99"
+    ],
+    "👦": [
+        "http://digitalcollections.nypl.org/items/3266ed40-2289-0132-cf76-58d385a7bbd0"
+    ],
+    "👧": [
+        "http://digitalcollections.nypl.org/items/37013680-2289-0132-5553-58d385a7bbd0"
+    ],
+    "👨": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c367-a3d9-e040-e00a18064a99"
+    ],
+    "👨‍❤️‍👨": [
+        "http://digitalcollections.nypl.org/items/510d47e3-9627-a3d9-e040-e00a18064a99"
+    ],
+    "👨‍❤️‍💋‍👨": [
+        "http://digitalcollections.nypl.org/items/510d47e3-b5a4-a3d9-e040-e00a18064a99"
+    ],
+    "👨‍👨‍👦": [
+        "http://digitalcollections.nypl.org/items/510d47e0-db9b-a3d9-e040-e00a18064a99"
+    ],
+    "👨‍👨‍👦‍👦": [
+        "http://digitalcollections.nypl.org/items/510d47e0-eb6e-a3d9-e040-e00a18064a99"
+    ],
+    "👨‍👨‍👧": [],
+    "👨‍👨‍👧‍👦": [],
+    "👨‍👨‍👧‍👧": [],
+    "👨‍👩‍👦": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-b7b0-d471-e040-e00a180654d7"
+    ],
+    "👨‍👩‍👦‍👦": [],
+    "👨‍👩‍👧": [
+        "http://digitalcollections.nypl.org/items/510d47df-1f42-a3d9-e040-e00a18064a99"
+    ],
+    "👨‍👩‍👧‍👦": [],
+    "👨‍👩‍👧‍👧": [
+        "http://digitalcollections.nypl.org/items/510d47df-950c-a3d9-e040-e00a18064a99"
+    ],
+    "👩": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f85f-a3d9-e040-e00a18064a99"
+    ],
+    "👩‍❤️‍👩": [
+        "http://digitalcollections.nypl.org/items/510d47e3-8353-a3d9-e040-e00a18064a99"
+    ],
+    "👩‍❤️‍💋‍👩": [
+        "http://digitalcollections.nypl.org/items/510d47e3-960e-a3d9-e040-e00a18064a99"
+    ],
+    "👩‍👩‍👦": [],
+    "👩‍👩‍👦‍👦": [],
+    "👩‍👩‍👧": [],
+    "👩‍👩‍👧‍👦": [],
+    "👩‍👩‍👧‍👧": [],
+    "👫": [
+        "http://digitalcollections.nypl.org/items/286a7aa0-024b-0133-d968-58d385a7bbd0"
+    ],
+    "👬": [
+        "http://digitalcollections.nypl.org/items/510d47e3-5788-a3d9-e040-e00a18064a99"
+    ],
+    "👭": [
+        "http://digitalcollections.nypl.org/items/510d47e3-b6cf-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-9f90-a3d9-e040-e00a18064a99"
+    ],
+    "👮": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-d81b-d471-e040-e00a180654d7"
+    ],
+    "👯": [
+        "http://digitalcollections.nypl.org/items/c3fd2980-5be0-0133-0793-00505686a51c",
+        "http://digitalcollections.nypl.org/items/8d028a2d-162d-adb4-e040-e00a18063458",
+        "http://digitalcollections.nypl.org/items/8df28a48-1bfb-56f0-e040-e00a1806391d",
+        "http://digitalcollections.nypl.org/items/1fd0d8c0-a895-0131-d091-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/afd620b0-d82f-2b70-e040-e00a180642e8"
+    ],
+    "👰": [
+        "http://digitalcollections.nypl.org/items/510d47e1-07b2-a3d9-e040-e00a18064a99"
+    ],
+    "👱": [
+        "http://digitalcollections.nypl.org/items/510d47e4-06ae-a3d9-e040-e00a18064a99"
+    ],
+    "👲": [
+        "http://digitalcollections.nypl.org/items/510d47e1-20da-a3d9-e040-e00a18064a99"
+    ],
+    "👳": [
+        "http://digitalcollections.nypl.org/items/510d47d9-623b-a3d9-e040-e00a18064a99"
+    ],
+    "👴": [
+        "http://digitalcollections.nypl.org/items/510d47e4-72a3-a3d9-e040-e00a18064a99"
+    ],
+    "👵": [
+        "http://digitalcollections.nypl.org/items/510d47e3-d870-a3d9-e040-e00a18064a99"
+    ],
+    "👶": [
+        "http://digitalcollections.nypl.org/items/510d47d9-3c9f-a3d9-e040-e00a18064a99"
+    ],
+    "👷": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a8fe-a3d9-e040-e00a18064a99"
+    ],
+    "👸": [
         "http://digitalcollections.nypl.org/items/9bb681a0-35da-4163-e040-e00a18062fe9",
         "http://digitalcollections.nypl.org/items/510d47df-f7eb-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/ef95b500-d5ad-012f-72a7-58d385a7b928"
     ],
-    "printer": [],
-    "punch": [],
-    "purple_heart":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6170-a3d9-e040-e00a18064a99"
+    "👹": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-72b3-d471-e040-e00a180654d7"
     ],
-    "purse":[
-        "http://digitalcollections.nypl.org/items/96d3c1ce-0b21-c226-e040-e00a1806422e"
+    "👺": [
+        "http://digitalcollections.nypl.org/items/510d47dc-885e-a3d9-e040-e00a18064a99"
     ],
-    "pushpin": [],
-    "put_litter_in_its_place":[
-        "http://digitalcollections.nypl.org/items/b153a2d9-9cc2-2146-e040-e00a18062823"
+    "👻": [
+        "http://digitalcollections.nypl.org/items/fd54ee00-82b7-0130-a9f2-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47e2-c549-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-c54a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-c54d-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-c507-a3d9-e040-e00a18064a99"
     ],
-    "question":[
-        "http://digitalcollections.nypl.org/items/c6d5d0ca-e348-54db-e040-e00a18063df6"
+    "👼": [
+        "http://digitalcollections.nypl.org/items/510d47e3-3e3d-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/79c4597e-dceb-8413-e040-e00a18066cd4"
     ],
-    "rabbit":[
-        "http://digitalcollections.nypl.org/items/510d47de-72ea-a3d9-e040-e00a18064a99"
+    "👽": [
+        "http://digitalcollections.nypl.org/items/510d47e2-9533-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-38f3-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-d565-a3d9-e040-e00a18064a99"
     ],
-    "rabbit2":[
-        "http://digitalcollections.nypl.org/items/510d47da-9c08-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/8c8c1916-8b75-426c-e040-e00a180650bb"
+    "👾": [
+        "http://digitalcollections.nypl.org/items/510d47de-3b05-a3d9-e040-e00a18064a99"
     ],
-    "racehorse":[
-        "http://digitalcollections.nypl.org/items/510d47e2-1af8-a3d9-e040-e00a18064a99"
+    "👿": [
+        "http://digitalcollections.nypl.org/items/6012d410-82b9-0130-376c-58d385a7bbd0"
     ],
-    "racing_car":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-1551-d471-e040-e00a180654d7"
+    "💀": [
+        "http://digitalcollections.nypl.org/items/74c9f570-82b9-0130-400f-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/6956ae61-c1d4-3815-e040-e00a18065ecc",
+        "http://digitalcollections.nypl.org/items/510d47db-3865-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-dd3d-d471-e040-e00a180654d7"
     ],
-    "racing_motorcycle":[
-        "http://digitalcollections.nypl.org/items/510d47e2-3c02-a3d9-e040-e00a18064a99"
+    "💁": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e93e-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47dd-eb84-a3d9-e040-e00a18064a99"
     ],
-    "radio": [
-        "http://digitalcollections.nypl.org/items/7b8172c8-b46b-d1a9-e040-e00a1806198a"    
+    "💂": [
+        "http://digitalcollections.nypl.org/items/510d47e0-e627-a3d9-e040-e00a18064a99"
     ],
-    "radio_button": [],
-    "radioactive_sign":[
-        "http://digitalcollections.nypl.org/items/510d47e2-09a9-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-9419-a3d9-e040-e00a18064a99"
+    "💃": [
+        "http://digitalcollections.nypl.org/items/67f427f0-ba01-0132-11ed-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47de-178a-a3d9-e040-e00a18064a99"
     ],
-    "rage": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e452-d471-e040-e00a180654d7"    
+    "💄": [
+        "http://digitalcollections.nypl.org/items/510d47e3-fa22-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/40a5a460-0857-0131-e369-58d385a7b928"
     ],
-    "railway_car": [],
-    "railway_track":[
-        "http://digitalcollections.nypl.org/items/510d47e1-8b78-a3d9-e040-e00a18064a99"
+    "💅": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-0461-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e3d7-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/04ca17e0-9abf-0132-7fe6-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47e2-1db4-a3d9-e040-e00a18064a99"
     ],
-    "rain_cloud":[
-        "http://digitalcollections.nypl.org/items/510d47e3-585b-a3d9-e040-e00a18064a99"
+    "💆": [
+        "http://digitalcollections.nypl.org/items/510d47e4-5db2-a3d9-e040-e00a18064a99"
     ],
-    "rainbow":[
-        "http://digitalcollections.nypl.org/items/510d47e2-49a1-a3d9-e040-e00a18064a99"
+    "💇": [
+        "http://digitalcollections.nypl.org/items/595ca3c0-964a-0130-2873-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/bbda5cb1-20b3-2132-e040-e00a18063b2f"
     ],
-    "raised_hand": [],
-    "raised_hand_with_fingers_splayed": [
-        "http://digitalcollections.nypl.org/items/5e05e730-1f96-0134-91ec-00505686a51c"
+    "💈": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4e68-a3d9-e040-e00a18064a99"
     ],
-    "raised_hands":[
-        "http://digitalcollections.nypl.org/items/510d47e3-5edd-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/7f787050-1a81-0132-7732-58d385a7bbd0"
+    "💉": [
+        "http://digitalcollections.nypl.org/items/510d47e3-62ab-a3d9-e040-e00a18064a99"
     ],
-    "raising_hand":[
-        "http://digitalcollections.nypl.org/items/645a6ee0-e7ab-0132-57c8-58d385a7bbd0"
+    "💊": [
+        "http://digitalcollections.nypl.org/items/510d47de-3aab-a3d9-e040-e00a18064a99"
     ],
-    "ram":[
-        "http://digitalcollections.nypl.org/items/510d47e2-d22f-a3d9-e040-e00a18064a99"
+    "💋": [
+        "http://digitalcollections.nypl.org/items/893c0fe7-8211-ad5f-e040-e00a18064278",
+        "http://digitalcollections.nypl.org/items/510d47e2-e5f6-a3d9-e040-e00a18064a99"
     ],
-    "ramen":[
-        "http://digitalcollections.nypl.org/items/ba355981-5687-de30-e040-e00a1806351c"
+    "💌": [
+        "http://digitalcollections.nypl.org/items/510d47db-df24-a3d9-e040-e00a18064a99"
     ],
-    "rat":[
-        "http://digitalcollections.nypl.org/items/510d47d9-57bd-a3d9-e040-e00a18064a99"
-    ],
-    "recycle": [],
-    "red_car": [],
-    "red_circle":[
-        "http://digitalcollections.nypl.org/items/510d47dc-3fb6-a3d9-e040-e00a18064a99"
-    ],
-    "registered":[
-        "http://digitalcollections.nypl.org/items/510d47e0-f1fb-a3d9-e040-e00a18064a99"
-    ],
-    "relaxed": [],
-    "relieved":[
-        "http://digitalcollections.nypl.org/items/b55236e0-a0f7-0132-a8de-58d385a7bbd0"
-    ],
-    "reminder_ribbon": [],
-    "repeat": [],
-    "repeat_one": [],
-    "restroom": [],
-    "reversed_hand_with_middle_finger_extended": [],
-    "revolving_hearts":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6174-a3d9-e040-e00a18064a99"
-    ],
-    "rewind": [],
-    "ribbon":[
-        "http://digitalcollections.nypl.org/items/510d47e3-b2e2-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-20d4-a3d9-e040-e00a18064a99"
-    ],
-    "rice":[
-        "http://digitalcollections.nypl.org/items/c261ef12-e4cc-3577-e040-e00a18067776"
-    ],
-    "rice_ball": [
-        "http://digitalcollections.nypl.org/items/a6249ebc-895b-849c-e040-e00a18060616"    
-    ],
-    "rice_cracker": [],
-    "rice_scene": [
-        "http://digitalcollections.nypl.org/items/510d47e1-cc3a-a3d9-e040-e00a18064a99"    
-    ],
-    "right_anger_bubble": [],
-    "ring":[
+    "💍": [
         "http://digitalcollections.nypl.org/items/91557149-480a-b3a8-e040-e00a18066846",
         "http://digitalcollections.nypl.org/items/510d47e2-1d28-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/91547316-3afb-c800-e040-e00a1806513c"
     ],
-    "robot_face":[
+    "💎": [
+        "http://digitalcollections.nypl.org/items/510d47e2-45d2-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-45d8-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-45d0-a3d9-e040-e00a18064a99"
+    ],
+    "💏": [
+        "http://digitalcollections.nypl.org/items/510d47e2-e5f6-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-9fef-a3d9-e040-e00a18064a99"
+    ],
+    "💐": [
+        "http://digitalcollections.nypl.org/items/510d47e3-922a-a3d9-e040-e00a18064a99"
+    ],
+    "💑": [
+        "http://digitalcollections.nypl.org/items/510d47e3-fc97-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-6499-a3d9-e040-e00a18064a99"
+    ],
+    "💒": [
+        "http://digitalcollections.nypl.org/items/510d47e2-d1a7-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-d0ea-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-d0ef-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-d1a8-a3d9-e040-e00a18064a99"
+    ],
+    "💓": [
+        "http://digitalcollections.nypl.org/items/510d47e1-08be-a3d9-e040-e00a18064a99"
+    ],
+    "💔": [
+        "http://digitalcollections.nypl.org/items/510d47da-708e-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47de-184a-a3d9-e040-e00a18064a99"
+    ],
+    "💕": [
+        "http://digitalcollections.nypl.org/items/510d47dd-b43d-a3d9-e040-e00a18064a99"
+    ],
+    "💖": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e567-a3d9-e040-e00a18064a99"
+    ],
+    "💗": [],
+    "💘": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6493-a3d9-e040-e00a18064a99"
+    ],
+    "💙": [
+        "http://digitalcollections.nypl.org/items/510d47e3-64b3-a3d9-e040-e00a18064a99"
+    ],
+    "💚": [
+        "http://digitalcollections.nypl.org/items/510d47e3-64c7-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-6198-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-64d3-a3d9-e040-e00a18064a99"
+    ],
+    "💛": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6170-a3d9-e040-e00a18064a99"
+    ],
+    "💜": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6170-a3d9-e040-e00a18064a99"
+    ],
+    "💝": [
+        "http://digitalcollections.nypl.org/items/510d47e3-64c1-a3d9-e040-e00a18064a99"
+    ],
+    "💞": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6174-a3d9-e040-e00a18064a99"
+    ],
+    "💟": [
+        "http://digitalcollections.nypl.org/items/510d47df-e40e-a3d9-e040-e00a18064a99"
+    ],
+    "💠": [],
+    "💡": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-82b0-d471-e040-e00a180654d7"
+    ],
+    "💢": [
+        "http://digitalcollections.nypl.org/items/510d47e2-dc0f-a3d9-e040-e00a18064a99"
+    ],
+    "💣": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b6c5-a3d9-e040-e00a18064a99"
+    ],
+    "💤": [
+        "http://digitalcollections.nypl.org/items/8bfbd237-2d18-aed1-e040-e00a1806680b"
+    ],
+    "💥": [
+        "http://digitalcollections.nypl.org/items/510d47d9-3f2a-a3d9-e040-e00a18064a99"
+    ],
+    "💦": [
+        "http://digitalcollections.nypl.org/items/8bfbd237-2d13-aed1-e040-e00a1806680b"
+    ],
+    "💧": [],
+    "💨": [
+        "http://digitalcollections.nypl.org/items/510d47e2-18a6-a3d9-e040-e00a18064a99"
+    ],
+    "💩": [
+        "http://digitalcollections.nypl.org/items/510d47e0-8081-a3d9-e040-e00a18064a99"
+    ],
+    "💪": [
+        "http://digitalcollections.nypl.org/items/510d47e2-3048-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/1f93e200-32dc-0132-7cf5-58d385a7bbd0"
+    ],
+    "💫": [
+        "http://digitalcollections.nypl.org/items/510d47e2-1d1c-a3d9-e040-e00a18064a99"
+    ],
+    "💬": [],
+    "💭": [
+        "http://digitalcollections.nypl.org/items/510d47de-862e-a3d9-e040-e00a18064a99"
+    ],
+    "💮": [
+        "http://digitalcollections.nypl.org/items/510d47e1-cae3-a3d9-e040-e00a18064a99"
+    ],
+    "💯": [
+        "http://digitalcollections.nypl.org/items/510d47e2-416c-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-f32a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-89b6-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/a87f2350-b9e7-0131-4b72-58d385a7bbd0"
+    ],
+    "💰": [
+        "http://digitalcollections.nypl.org/items/510d47e2-331e-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/7456f4d0-bb89-0132-37ab-58d385a7bbd0"
+    ],
+    "💱": [],
+    "💲": [],
+    "💳": [],
+    "💴": [],
+    "💵": [
+        "http://digitalcollections.nypl.org/items/510d47e3-5334-a3d9-e040-e00a18064a99"
+    ],
+    "💶": [],
+    "💷": [],
+    "💸": [],
+    "💹": [],
+    "💺": [
+        "http://digitalcollections.nypl.org/items/510d47e2-e1b9-a3d9-e040-e00a18064a99"
+    ],
+    "💻": [],
+    "💼": [
+        "http://digitalcollections.nypl.org/items/510d47e0-f018-a3d9-e040-e00a18064a99"
+    ],
+    "💽": [],
+    "💾": [],
+    "💿": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-0888-d471-e040-e00a180654d7"
+    ],
+    "📀": [],
+    "📁": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c9d1-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-c757-a3d9-e040-e00a18064a99"
+    ],
+    "📂": [],
+    "📃": [
+        "http://digitalcollections.nypl.org/items/510d47d9-857a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/893c0fe7-8275-ad5f-e040-e00a18064278"
+    ],
+    "📄": [
+        "http://digitalcollections.nypl.org/items/510d47df-d584-a3d9-e040-e00a18064a99"
+    ],
+    "📅": [
+        "http://digitalcollections.nypl.org/items/510d47de-66df-a3d9-e040-e00a18064a99"
+    ],
+    "📆": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-6d47-d471-e040-e00a180654d7"
+    ],
+    "📇": [],
+    "📈": [
+        "http://digitalcollections.nypl.org/items/510d47db-d7fb-a3d9-e040-e00a18064a99"
+    ],
+    "📉": [],
+    "📊": [
+        "http://digitalcollections.nypl.org/items/e6782a70-4117-0132-82c6-58d385a7b928"
+    ],
+    "📋": [
+        "http://digitalcollections.nypl.org/items/510d47dd-9cae-a3d9-e040-e00a18064a99"
+    ],
+    "📌": [],
+    "📍": [],
+    "📎": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e20f-a3d9-e040-e00a18064a99"
+    ],
+    "📏": [
+        "http://digitalcollections.nypl.org/items/510d47df-f9f7-a3d9-e040-e00a18064a99"
+    ],
+    "📐": [
+        "http://digitalcollections.nypl.org/items/510d47df-fa20-a3d9-e040-e00a18064a99"
+    ],
+    "📑": [
+        "http://digitalcollections.nypl.org/items/510d47da-e3aa-a3d9-e040-e00a18064a99"
+    ],
+    "📒": [
+        "http://digitalcollections.nypl.org/items/28ba45d0-ba67-0130-4c75-58d385a7b928"
+    ],
+    "📓": [
+        "http://digitalcollections.nypl.org/items/4f10fef0-e81a-0131-198c-58d385a7b928"
+    ],
+    "📔": [
+        "http://digitalcollections.nypl.org/items/d9723ca0-57d4-0132-6ad4-58d385a7bbd0"
+    ],
+    "📕": [
+        "http://digitalcollections.nypl.org/items/510d47dc-965b-a3d9-e040-e00a18064a99"
+    ],
+    "📖": [
+        "http://digitalcollections.nypl.org/items/510d47da-4715-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-cefa-a3d9-e040-e00a18064a99"
+    ],
+    "📗": [
+        "http://digitalcollections.nypl.org/items/dc858e50-83d3-0132-2266-58d385a7b928"
+    ],
+    "📘": [
+        "http://digitalcollections.nypl.org/items/510d47db-c96b-a3d9-e040-e00a18064a99"
+    ],
+    "📙": [
+        "http://digitalcollections.nypl.org/items/510d47dc-4031-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/54011580-5c94-0132-2f7a-58d385a7bbd0"
+    ],
+    "📚": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e4ca-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47df-e348-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-8245-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-eb75-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-eb79-a3d9-e040-e00a18064a99"
+    ],
+    "📛": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ca06-d471-e040-e00a180654d7"
+    ],
+    "📜": [
+        "http://digitalcollections.nypl.org/items/510d47e1-d75b-a3d9-e040-e00a18064a99"
+    ],
+    "📝": [
+        "http://digitalcollections.nypl.org/items/510d47db-5169-a3d9-e040-e00a18064a99"
+    ],
+    "📞": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ee59-d471-e040-e00a180654d7"
+    ],
+    "📟": [],
+    "📠": [],
+    "📢": [],
+    "📣": [
+        "http://digitalcollections.nypl.org/items/510d47e0-eea9-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e1-22ec-a3d9-e040-e00a18064a99"
+    ],
+    "📤": [],
+    "📥": [],
+    "📦": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b7da-a3d9-e040-e00a18064a99"
+    ],
+    "📧": [],
+    "📨": [
+        "http://digitalcollections.nypl.org/items/510d47e3-565c-a3d9-e040-e00a18064a99"
+    ],
+    "📩": [
+        "http://digitalcollections.nypl.org/items/510d47e3-565c-a3d9-e040-e00a18064a99"
+    ],
+    "📪": [
+        "http://digitalcollections.nypl.org/items/86c7de60-08a5-0133-21a7-58d385a7bbd0"
+    ],
+    "📫": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b802-a3d9-e040-e00a18064a99"
+    ],
+    "📬": [
+        "http://digitalcollections.nypl.org/items/510d47e3-6184-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-3d34-a3d9-e040-e00a18064a99"
+    ],
+    "📭": [
+        "http://digitalcollections.nypl.org/items/510d47dd-8634-a3d9-e040-e00a18064a99"
+    ],
+    "📮": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b829-a3d9-e040-e00a18064a99"
+    ],
+    "📯": [
+        "http://digitalcollections.nypl.org/items/a4958095-46e9-074d-e040-e00a1806792c"
+    ],
+    "📰": [
+        "http://digitalcollections.nypl.org/items/510d47de-38fd-a3d9-e040-e00a18064a99"
+    ],
+    "📱": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-bb79-d471-e040-e00a180654d7"
+    ],
+    "📲": [],
+    "📳": [],
+    "📴": [],
+    "📵": [],
+    "📶": [
+        "http://digitalcollections.nypl.org/items/9413e341-32e4-7c92-e040-e00a18064d91"
+    ],
+    "📷": [
+        "http://digitalcollections.nypl.org/items/510d47e2-4778-a3d9-e040-e00a18064a99"
+    ],
+    "📸": [
+        "http://digitalcollections.nypl.org/items/b153a2d9-9cd0-2146-e040-e00a18062823"
+    ],
+    "📹": [],
+    "📺": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-95ad-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-9d7a-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-f864-d471-e040-e00a180654d7"
+    ],
+    "📻": [
+        "http://digitalcollections.nypl.org/items/7b8172c8-b46b-d1a9-e040-e00a1806198a"
+    ],
+    "📼": [
+        "http://digitalcollections.nypl.org/items/9fa5d371-825d-7bd0-e040-e00a180606c8"
+    ],
+    "📽": [
+        "http://digitalcollections.nypl.org/items/510d47da-92cd-a3d9-e040-e00a18064a99"
+    ],
+    "📿": [
+        "http://digitalcollections.nypl.org/items/510d47e1-17f8-a3d9-e040-e00a18064a99"
+    ],
+    "🔀": [],
+    "🔁": [],
+    "🔂": [],
+    "🔃": [
+        "http://digitalcollections.nypl.org/items/510d47dc-836e-a3d9-e040-e00a18064a99"
+    ],
+    "🔄": [
+        "http://digitalcollections.nypl.org/items/510d47e2-1dac-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-5a8c-a3d9-e040-e00a18064a99"
+    ],
+    "🔅": [],
+    "🔆": [],
+    "🔇": [],
+    "🔈": [],
+    "🔉": [],
+    "🔊": [],
+    "🔋": [],
+    "🔌": [],
+    "🔍": [],
+    "🔎": [],
+    "🔏": [],
+    "🔐": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c7c5-a3d9-e040-e00a18064a99"
+    ],
+    "🔑": [
+        "http://digitalcollections.nypl.org/items/510d47df-a19d-a3d9-e040-e00a18064a99"
+    ],
+    "🔒": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7a85-a3d9-e040-e00a18064a99"
+    ],
+    "🔓": [],
+    "🔔": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a62e-a3d9-e040-e00a18064a99"
+    ],
+    "🔕": [
+        "http://digitalcollections.nypl.org/items/510d47e0-ab68-a3d9-e040-e00a18064a99"
+    ],
+    "🔖": [
+        "http://digitalcollections.nypl.org/items/9eff8bbf-ca5d-c3c0-e040-e00a1806603f"
+    ],
+    "🔗": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b6e5-a3d9-e040-e00a18064a99"
+    ],
+    "🔘": [],
+    "🔙": [],
+    "🔚": [],
+    "🔛": [],
+    "🔜": [],
+    "🔝": [],
+    "🔞": [
+        "http://digitalcollections.nypl.org/items/3f9ffdd0-08f0-0131-9724-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/9c91972e-ca67-25ad-e040-e00a18063ca7"
+    ],
+    "🔟": [
+        "http://digitalcollections.nypl.org/items/510d47e3-972c-a3d9-e040-e00a18064a99"
+    ],
+    "🔠": [
+        "http://digitalcollections.nypl.org/items/6b26eaac-2bae-1da7-e040-e00a18062258"
+    ],
+    "🔡": [],
+    "🔢": [],
+    "🔣": [],
+    "🔤": [
+        "http://digitalcollections.nypl.org/items/b0d65bdd-789d-7d0a-e040-e00a18065084"
+    ],
+    "🔥": [
+        "http://digitalcollections.nypl.org/items/510d47e2-fd9a-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-e537-a3d9-e040-e00a18064a99"
+    ],
+    "🔦": [
+        "http://digitalcollections.nypl.org/items/9a622aeb-9096-d2a0-e040-e00a180601cc",
+        "http://digitalcollections.nypl.org/items/510d47da-4eff-a3d9-e040-e00a18064a99"
+    ],
+    "🔧": [
+        "http://digitalcollections.nypl.org/items/510d47e4-4a9e-a3d9-e040-e00a18064a99"
+    ],
+    "🔨": [
+        "http://digitalcollections.nypl.org/items/510d47de-1ad3-a3d9-e040-e00a18064a99"
+    ],
+    "🔩": [
+        "http://digitalcollections.nypl.org/items/510d47df-fa1b-a3d9-e040-e00a18064a99"
+    ],
+    "🔪": [
+        "http://digitalcollections.nypl.org/items/510d47de-38ab-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47da-d15e-a3d9-e040-e00a18064a99"
+    ],
+    "🔫": [
+        "http://digitalcollections.nypl.org/items/510d47e2-cda9-a3d9-e040-e00a18064a99"
+    ],
+    "🔬": [
+        "http://digitalcollections.nypl.org/items/510d47e2-47a4-a3d9-e040-e00a18064a99"
+    ],
+    "🔭": [
+        "http://digitalcollections.nypl.org/items/892929d8-2b6f-cc7d-e040-e00a18063fb3"
+    ],
+    "🔮": [
+        "http://digitalcollections.nypl.org/items/510d47e1-3cc5-a3d9-e040-e00a18064a99"
+    ],
+    "🔯": [
+        "http://digitalcollections.nypl.org/items/510d47dc-4037-a3d9-e040-e00a18064a99"
+    ],
+    "🔰": [
+        "http://digitalcollections.nypl.org/items/510d47db-c934-a3d9-e040-e00a18064a99"
+    ],
+    "🔱": [
+        "http://digitalcollections.nypl.org/items/574b0ec0-a3a9-0130-fa2b-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/5b487340-1d8a-0131-fdbd-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/510d47da-edbc-a3d9-e040-e00a18064a99"
+    ],
+    "🔲": [
+        "http://digitalcollections.nypl.org/items/510d47da-ec7d-a3d9-e040-e00a18064a99"
+    ],
+    "🔳": [],
+    "🔴": [
+        "http://digitalcollections.nypl.org/items/510d47dc-3fb6-a3d9-e040-e00a18064a99"
+    ],
+    "🔵": [
+        "http://digitalcollections.nypl.org/items/510d47e2-e24c-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-a00f-a3d9-e040-e00a18064a99"
+    ],
+    "🔶": [
+        "http://digitalcollections.nypl.org/items/510d47dc-41f4-a3d9-e040-e00a18064a99"
+    ],
+    "🔷": [
+        "http://digitalcollections.nypl.org/items/510d47e2-45d2-a3d9-e040-e00a18064a99"
+    ],
+    "🔸": [],
+    "🔹": [],
+    "🔺": [],
+    "🔻": [],
+    "🔼": [],
+    "🔽": [],
+    "🕉": [],
+    "🕊": [
+        "http://digitalcollections.nypl.org/items/510d47e2-e61a-a3d9-e040-e00a18064a99"
+    ],
+    "🕋": [
+        "http://digitalcollections.nypl.org/items/510d47dc-47ad-a3d9-e040-e00a18064a99"
+    ],
+    "🕌": [
+        "http://digitalcollections.nypl.org/items/510d47d9-5c6b-a3d9-e040-e00a18064a99"
+    ],
+    "🕍": [
+        "http://digitalcollections.nypl.org/items/510d47e0-1efa-a3d9-e040-e00a18064a99"
+    ],
+    "🕎": [
+        "http://digitalcollections.nypl.org/items/510d47de-1cc6-a3d9-e040-e00a18064a99"
+    ],
+    "🕐": [
+        "http://digitalcollections.nypl.org/items/510d47de-3abd-a3d9-e040-e00a18064a99"
+    ],
+    "🕑": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7762-a3d9-e040-e00a18064a99"
+    ],
+    "🕒": [
+        "http://digitalcollections.nypl.org/items/ebc895c0-f368-0132-6737-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47de-3319-a3d9-e040-e00a18064a99"
+    ],
+    "🕓": [
+        "http://digitalcollections.nypl.org/items/510d47e1-a724-a3d9-e040-e00a18064a99"
+    ],
+    "🕔": [
+        "http://digitalcollections.nypl.org/items/510d47db-875b-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47de-8190-a3d9-e040-e00a18064a99"
+    ],
+    "🕕": [],
+    "🕖": [
+        "http://digitalcollections.nypl.org/items/510d47de-818f-a3d9-e040-e00a18064a99"
+    ],
+    "🕗": [
+        "http://digitalcollections.nypl.org/items/510d47e0-ccd5-a3d9-e040-e00a18064a99"
+    ],
+    "🕘": [
+        "http://digitalcollections.nypl.org/items/510d47e1-160c-a3d9-e040-e00a18064a99"
+    ],
+    "🕙": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-79d7-d471-e040-e00a180654d7"
+    ],
+    "🕚": [
+        "http://digitalcollections.nypl.org/items/510d47da-d221-a3d9-e040-e00a18064a99"
+    ],
+    "🕛": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-26e5-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47e3-47d5-a3d9-e040-e00a18064a99"
+    ],
+    "🕜": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-9e6c-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47de-8192-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-897d-a3d9-e040-e00a18064a99"
+    ],
+    "🕝": [
+        "http://digitalcollections.nypl.org/items/510d47de-3317-a3d9-e040-e00a18064a99"
+    ],
+    "🕞": [
+        "http://digitalcollections.nypl.org/items/510d47de-32f5-a3d9-e040-e00a18064a99"
+    ],
+    "🕟": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7aa7-a3d9-e040-e00a18064a99"
+    ],
+    "🕠": [
+        "http://digitalcollections.nypl.org/items/510d47dc-3a56-a3d9-e040-e00a18064a99"
+    ],
+    "🕡": [
+        "http://digitalcollections.nypl.org/items/510d47dd-a65b-a3d9-e040-e00a18064a99"
+    ],
+    "🕢": [],
+    "🕣": [
+        "http://digitalcollections.nypl.org/items/510d47e1-25a1-a3d9-e040-e00a18064a99"
+    ],
+    "🕤": [
+        "http://digitalcollections.nypl.org/items/510d47db-a48d-a3d9-e040-e00a18064a99"
+    ],
+    "🕥": [
+        "http://digitalcollections.nypl.org/items/510d47de-3313-a3d9-e040-e00a18064a99"
+    ],
+    "🕦": [
+        "http://digitalcollections.nypl.org/items/510d47db-47c6-a3d9-e040-e00a18064a99"
+    ],
+    "🕧": [
+        "http://digitalcollections.nypl.org/items/510d47dc-3ef4-a3d9-e040-e00a18064a99"
+    ],
+    "🕯": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-d388-d471-e040-e00a180654d7"
+    ],
+    "🕰": [],
+    "🕳": [
+        "http://digitalcollections.nypl.org/items/510d47de-009c-a3d9-e040-e00a18064a99"
+    ],
+    "🕴": [
+        "http://digitalcollections.nypl.org/items/510d47da-4ed6-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/b5cfbf49-a5a0-7548-e040-e00a18060aef"
+    ],
+    "🕵": [
+        "http://digitalcollections.nypl.org/items/510d47e1-2316-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47d9-b975-a3d9-e040-e00a18064a99"
+    ],
+    "🕶": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-0cda-d471-e040-e00a180654d7"
+    ],
+    "🕷": [
+        "http://digitalcollections.nypl.org/items/510d47e1-087b-a3d9-e040-e00a18064a99"
+    ],
+    "🕸": [
+        "http://digitalcollections.nypl.org/items/510d47e1-0888-a3d9-e040-e00a18064a99"
+    ],
+    "🕹": [],
+    "🖇": [
+        "http://digitalcollections.nypl.org/items/510d47dd-e20f-a3d9-e040-e00a18064a99"
+    ],
+    "🖊": [],
+    "🖋": [],
+    "🖌": [
+        "http://digitalcollections.nypl.org/items/510d47e4-7ab5-a3d9-e040-e00a18064a99"
+    ],
+    "🖍": [],
+    "🖐": [
+        "http://digitalcollections.nypl.org/items/5e05e730-1f96-0134-91ec-00505686a51c"
+    ],
+    "🖕": [],
+    "🖖": [
+        "http://digitalcollections.nypl.org/items/152d9370-9f4d-0132-f97d-58d385a7bbd0"
+    ],
+    "🖥": [],
+    "🖨": [],
+    "🖱": [],
+    "🖲": [],
+    "🖼": [
+        "http://digitalcollections.nypl.org/items/5cf22630-9cbc-0131-4c57-58d385a7b928"
+    ],
+    "🗂": [],
+    "🗃": [],
+    "🗄": [
+        "http://digitalcollections.nypl.org/items/510d47dd-eb5f-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47df-ac6b-a3d9-e040-e00a18064a99"
+    ],
+    "🗑": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-70af-d471-e040-e00a180654d7"
+    ],
+    "🗒": [
+        "http://digitalcollections.nypl.org/items/28ba45d0-ba67-0130-4c75-58d385a7b928"
+    ],
+    "🗓": [
+        "http://digitalcollections.nypl.org/items/510d47e3-afbc-a3d9-e040-e00a18064a99"
+    ],
+    "🗜": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4ea7-a3d9-e040-e00a18064a99"
+    ],
+    "🗝": [
+        "http://digitalcollections.nypl.org/items/510d47e3-2549-a3d9-e040-e00a18064a99"
+    ],
+    "🗞": [],
+    "🗡": [
+        "http://digitalcollections.nypl.org/items/510d47e3-8fe7-a3d9-e040-e00a18064a99"
+    ],
+    "🗣": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-768c-d471-e040-e00a180654d7"
+    ],
+    "🗨": [],
+    "🗯": [],
+    "🗳": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-80cd-d471-e040-e00a180654d7"
+    ],
+    "🗺": [
+        "http://digitalcollections.nypl.org/items/510d47e3-719e-a3d9-e040-e00a18064a99"
+    ],
+    "🗻": [
+        "http://digitalcollections.nypl.org/items/c260bdb3-9b61-4552-e040-e00a18066d81"
+    ],
+    "🗼": [
+        "http://digitalcollections.nypl.org/items/6afd4e50-f3da-0130-6b32-58d385a7bbd0"
+    ],
+    "🗽": [
+        "http://digitalcollections.nypl.org/items/510d47de-0a2c-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/0328dfd0-c254-0130-6535-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/510d47e4-6636-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47de-0a2d-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-8e33-a3d9-e040-e00a18064a99"
+    ],
+    "🗾": [
+        "http://digitalcollections.nypl.org/items/510d47e4-08e1-a3d9-e040-e00a18064a99"
+    ],
+    "🗿": [
+        "http://digitalcollections.nypl.org/items/510d47e3-ad5d-a3d9-e040-e00a18064a99"
+    ],
+    "😀": [],
+    "😁": [
+        "http://digitalcollections.nypl.org/items/0b834ba0-e8f3-0130-12cc-58d385a7bbd0"
+    ],
+    "😂": [
+        "http://digitalcollections.nypl.org/items/510d47df-f1d0-a3d9-e040-e00a18064a99"
+    ],
+    "😃": [],
+    "😄": [
+        "http://digitalcollections.nypl.org/items/510d47e0-ed58-a3d9-e040-e00a18064a99"
+    ],
+    "😅": [
+        "http://digitalcollections.nypl.org/items/d1c0bf40-2d4c-0132-e5bd-58d385a7b928"
+    ],
+    "😆": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-a2c4-d471-e040-e00a180654d7"
+    ],
+    "😇": [
+        "http://digitalcollections.nypl.org/items/591ccad0-da38-0132-90f2-58d385a7b928"
+    ],
+    "😈": [
+        "http://digitalcollections.nypl.org/items/3547ff80-82b8-0130-ac49-58d385a7bbd0"
+    ],
+    "😉": [
+        "http://digitalcollections.nypl.org/items/0e56d120-6988-0130-fe6e-58d385a7b928"
+    ],
+    "😊": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f3cb-a3d9-e040-e00a18064a99"
+    ],
+    "😋": [
+        "http://digitalcollections.nypl.org/items/510d47e1-43c5-a3d9-e040-e00a18064a99"
+    ],
+    "😌": [
+        "http://digitalcollections.nypl.org/items/b55236e0-a0f7-0132-a8de-58d385a7bbd0"
+    ],
+    "😍": [
+        "http://digitalcollections.nypl.org/items/510d47e3-649b-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-5cb5-a3d9-e040-e00a18064a99"
+    ],
+    "😎": [
+        "http://digitalcollections.nypl.org/items/081422c0-2289-0132-7f45-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/8af99501-836d-161c-e040-e00a18064530"
+    ],
+    "😏": [
+        "http://digitalcollections.nypl.org/items/70833100-aafa-0132-1ad3-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/5e66b3e9-244e-d471-e040-e00a180654d7"
+    ],
+    "😐": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f72f-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/d4087230-f215-0130-69b3-58d385a7b928"
+    ],
+    "😑": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-7561-3443-e040-e00a18067692"
+    ],
+    "😒": [
+        "http://digitalcollections.nypl.org/items/510d47e1-784c-a3d9-e040-e00a18064a99"
+    ],
+    "😓": [
+        "http://digitalcollections.nypl.org/items/6762c9d0-93fd-0130-ee5a-58d385a7b928"
+    ],
+    "😔": [
+        "http://digitalcollections.nypl.org/items/510d47e3-7253-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/65234070-a456-0130-bd40-58d385a7bbd0"
+    ],
+    "😕": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-756b-3443-e040-e00a18067692"
+    ],
+    "😖": [
+        "http://digitalcollections.nypl.org/items/f85e0e90-f8d3-0132-bd5f-58d385a7b928"
+    ],
+    "😗": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4eb3-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/bc76a6fe-2dea-6f87-e040-e00a18067e76"
+    ],
+    "😘": [
+        "http://digitalcollections.nypl.org/items/023648b0-bb8c-0132-bcbd-58d385a7bbd0"
+    ],
+    "😙": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-9ef4-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/b31f5d33-816b-17da-e040-e00a18062482",
+        "http://digitalcollections.nypl.org/items/5e66b3e8-8ca7-d471-e040-e00a180654d7"
+    ],
+    "😚": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-f9f3-d471-e040-e00a180654d7"
+    ],
+    "😛": [
+        "http://digitalcollections.nypl.org/items/510d47e2-c6d1-a3d9-e040-e00a18064a99"
+    ],
+    "😜": [
+        "http://digitalcollections.nypl.org/items/510d47e3-64ab-a3d9-e040-e00a18064a99"
+    ],
+    "😝": [
+        "http://digitalcollections.nypl.org/items/510d47dd-f278-a3d9-e040-e00a18064a99"
+    ],
+    "😞": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-757f-3443-e040-e00a18067692"
+    ],
+    "😟": [
+        "http://digitalcollections.nypl.org/items/6b27a1d9-1d61-b8da-e040-e00a18062c91"
+    ],
+    "😠": [
+        "http://digitalcollections.nypl.org/items/510d47da-9ede-a3d9-e040-e00a18064a99"
+    ],
+    "😡": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-e452-d471-e040-e00a180654d7"
+    ],
+    "😢": [
+        "http://digitalcollections.nypl.org/items/510d47da-44d8-a3d9-e040-e00a18064a99"
+    ],
+    "😣": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-217b-d471-e040-e00a180654d7"
+    ],
+    "😤": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ddad-d471-e040-e00a180654d7"
+    ],
+    "😥": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-7591-3443-e040-e00a18067692"
+    ],
+    "😦": [
+        "http://digitalcollections.nypl.org/items/510d47de-2a29-a3d9-e040-e00a18064a99"
+    ],
+    "😧": [],
+    "😨": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-75d7-3443-e040-e00a18067692"
+    ],
+    "😩": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f6f9-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-7853-a3d9-e040-e00a18064a99"
+    ],
+    "😪": [
+        "http://digitalcollections.nypl.org/items/9152d417-7eae-9ea8-e040-e00a18064db0",
+        "http://digitalcollections.nypl.org/items/510d47e1-19ef-a3d9-e040-e00a18064a99"
+    ],
+    "😫": [
+        "http://digitalcollections.nypl.org/items/90f27b23-76af-2d20-e040-e00a18064b4d"
+    ],
+    "😬": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-759b-3443-e040-e00a18067692"
+    ],
+    "😭": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-c153-d471-e040-e00a180654d7"
+    ],
+    "😮": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-75c7-3443-e040-e00a18067692",
+        "http://digitalcollections.nypl.org/items/8bfbd237-2d0f-aed1-e040-e00a1806680b"
+    ],
+    "😯": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f719-a3d9-e040-e00a18064a99"
+    ],
+    "😰": [
+        "http://digitalcollections.nypl.org/items/510d47e2-ffca-a3d9-e040-e00a18064a99"
+    ],
+    "😱": [
+        "http://digitalcollections.nypl.org/items/510d47e1-375b-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/8bfbd237-2d0f-aed1-e040-e00a1806680b"
+    ],
+    "😲": [
+        "http://digitalcollections.nypl.org/items/70833100-aafa-0132-1ad3-58d385a7bbd0"
+    ],
+    "😳": [
+        "http://digitalcollections.nypl.org/items/510d47e2-f713-a3d9-e040-e00a18064a99"
+    ],
+    "😴": [
+        "http://digitalcollections.nypl.org/items/510d47e3-3e49-a3d9-e040-e00a18064a99"
+    ],
+    "😵": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-75d3-3443-e040-e00a18067692"
+    ],
+    "😶": [
+        "http://digitalcollections.nypl.org/items/510d47da-f3e9-a3d9-e040-e00a18064a99"
+    ],
+    "😷": [
+        "http://digitalcollections.nypl.org/items/2d70eaa0-0439-0131-fd4f-58d385a7b928"
+    ],
+    "😸": [
+        "http://digitalcollections.nypl.org/items/510d47dd-f4ac-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-8f35-a3d9-e040-e00a18064a99"
+    ],
+    "😹": [
+        "http://digitalcollections.nypl.org/items/510d47da-9b89-a3d9-e040-e00a18064a99"
+    ],
+    "😺": [
+        "http://digitalcollections.nypl.org/items/33a1aae0-e04c-0131-00cf-58d385a7bbd0"
+    ],
+    "😻": [
+        "http://digitalcollections.nypl.org/items/510d47de-ea0c-a3d9-e040-e00a18064a99"
+    ],
+    "😼": [
+        "http://digitalcollections.nypl.org/items/510d47e1-43b5-a3d9-e040-e00a18064a99"
+    ],
+    "😽": [
+        "http://digitalcollections.nypl.org/items/68a46690-e04c-0131-ddd9-58d385a7bbd0"
+    ],
+    "😾": [
+        "http://digitalcollections.nypl.org/items/510d47de-6c0a-a3d9-e040-e00a18064a99"
+    ],
+    "😿": [
+        "http://digitalcollections.nypl.org/items/510d47de-ea0d-a3d9-e040-e00a18064a99"
+    ],
+    "🙀": [
+        "http://digitalcollections.nypl.org/items/510d47da-9b69-a3d9-e040-e00a18064a99"
+    ],
+    "🙁": [
+        "http://digitalcollections.nypl.org/items/510d47e1-43c1-a3d9-e040-e00a18064a99"
+    ],
+    "🙂": [
+        "http://digitalcollections.nypl.org/items/d9a432d0-e04a-0131-8623-58d385a7bbd0"
+    ],
+    "🙃": [
+        "http://digitalcollections.nypl.org/items/8d6a1137-4bf6-1b84-e040-e00a1806585b",
+        "http://digitalcollections.nypl.org/items/8d9313d0-97f0-9154-e040-e00a1806770f"
+    ],
+    "🙄": [
+        "http://digitalcollections.nypl.org/items/aa16d2ae-75ed-3443-e040-e00a18067692"
+    ],
+    "🙅": [
+        "http://digitalcollections.nypl.org/items/dd3071c0-0dfe-0133-97a8-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/5f614ec0-8b73-0131-8cb9-58d385a7b928"
+    ],
+    "🙆": [
+        "http://digitalcollections.nypl.org/items/895df880-1e95-0133-4698-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/991bd460-9cbc-0131-8aed-58d385a7b928",
+        "http://digitalcollections.nypl.org/items/148fc990-7de4-0130-f59a-58d385a7b928"
+    ],
+    "🙇": [
+        "http://digitalcollections.nypl.org/items/c8526e10-2571-0132-437b-58d385a7b928"
+    ],
+    "🙈": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c693-a3d9-e040-e00a18064a99"
+    ],
+    "🙉": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c695-a3d9-e040-e00a18064a99"
+    ],
+    "🙊": [
+        "http://digitalcollections.nypl.org/items/510d47d9-c695-a3d9-e040-e00a18064a99"
+    ],
+    "🙋": [
+        "http://digitalcollections.nypl.org/items/645a6ee0-e7ab-0132-57c8-58d385a7bbd0"
+    ],
+    "🙌": [
+        "http://digitalcollections.nypl.org/items/510d47e3-5edd-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/7f787050-1a81-0132-7732-58d385a7bbd0"
+    ],
+    "🙍": [
+        "http://digitalcollections.nypl.org/items/510d47d9-a83a-a3d9-e040-e00a18064a99"
+    ],
+    "🙎": [],
+    "🙏": [
+        "http://digitalcollections.nypl.org/items/510d47da-e4b4-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/72c56f40-f5fd-012f-768d-58d385a7bbd0"
+    ],
+    "🚀": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-05fc-d471-e040-e00a180654d7",
+        "http://digitalcollections.nypl.org/items/510d47df-4539-a3d9-e040-e00a18064a99"
+    ],
+    "🚁": [
+        "http://digitalcollections.nypl.org/items/510d47da-94f2-a3d9-e040-e00a18064a99"
+    ],
+    "🚂": [
+        "http://digitalcollections.nypl.org/items/510d47e3-617c-a3d9-e040-e00a18064a99"
+    ],
+    "🚃": [],
+    "🚄": [],
+    "🚅": [],
+    "🚆": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-06b9-d471-e040-e00a180654d7"
+    ],
+    "🚇": [
+        "http://digitalcollections.nypl.org/items/510d47e1-062f-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-8ce3-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-8cdf-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/661b0b70-a456-0130-bf20-58d385a7bbd0"
+    ],
+    "🚈": [],
+    "🚉": [
+        "http://digitalcollections.nypl.org/items/510d47e4-8418-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/9154e0ad-1c25-6f41-e040-e00a180667ae"
+    ],
+    "🚊": [
+        "http://digitalcollections.nypl.org/items/510d47e2-478a-a3d9-e040-e00a18064a99"
+    ],
+    "🚋": [],
+    "🚌": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-da0e-d471-e040-e00a180654d7"
+    ],
+    "🚍": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-a28c-d471-e040-e00a180654d7"
+    ],
+    "🚎": [
+        "http://digitalcollections.nypl.org/items/510d47db-b897-a3d9-e040-e00a18064a99"
+    ],
+    "🚏": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4f7c-a3d9-e040-e00a18064a99"
+    ],
+    "🚐": [
+        "http://digitalcollections.nypl.org/items/510d47db-b776-a3d9-e040-e00a18064a99"
+    ],
+    "🚑": [
+        "http://digitalcollections.nypl.org/items/510d47e4-25f6-a3d9-e040-e00a18064a99"
+    ],
+    "🚒": [
+        "http://digitalcollections.nypl.org/items/510d47db-b75f-a3d9-e040-e00a18064a99"
+    ],
+    "🚓": [],
+    "🚔": [],
+    "🚕": [
+        "http://digitalcollections.nypl.org/items/b06e6ba0-8a28-0132-fba5-58d385a7bbd0"
+    ],
+    "🚖": [
+        "http://digitalcollections.nypl.org/items/ae6c1dd9-56b6-f55a-e040-e00a18062565"
+    ],
+    "🚗": [
+        "http://digitalcollections.nypl.org/items/510d47da-b8a9-a3d9-e040-e00a18064a99"
+    ],
+    "🚘": [
+        "http://digitalcollections.nypl.org/items/6f02b7d0-ea71-0131-8e9f-58d385a7bbd0"
+    ],
+    "🚙": [
+        "http://digitalcollections.nypl.org/items/510d47da-d985-a3d9-e040-e00a18064a99"
+    ],
+    "🚚": [
+        "http://digitalcollections.nypl.org/items/510d47db-b77e-a3d9-e040-e00a18064a99"
+    ],
+    "🚛": [
+        "http://digitalcollections.nypl.org/items/510d47db-b763-a3d9-e040-e00a18064a99"
+    ],
+    "🚜": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-8dc5-d471-e040-e00a180654d7"
+    ],
+    "🚝": [
+        "http://digitalcollections.nypl.org/items/917bb7f6-f58e-6224-e040-e00a180679cb"
+    ],
+    "🚞": [
+        "http://digitalcollections.nypl.org/items/510d47e1-8a0a-a3d9-e040-e00a18064a99"
+    ],
+    "🚟": [],
+    "🚠": [
+        "http://digitalcollections.nypl.org/items/510d47e1-9230-a3d9-e040-e00a18064a99"
+    ],
+    "🚡": [
+        "http://digitalcollections.nypl.org/items/510d47e4-5a97-a3d9-e040-e00a18064a99"
+    ],
+    "🚢": [
+        "http://digitalcollections.nypl.org/items/510d47dd-fb8e-a3d9-e040-e00a18064a99"
+    ],
+    "🚣": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b9a3-a3d9-e040-e00a18064a99"
+    ],
+    "🚤": [
+        "http://digitalcollections.nypl.org/items/510d47de-76bc-a3d9-e040-e00a18064a99"
+    ],
+    "🚥": [],
+    "🚦": [
+        "http://digitalcollections.nypl.org/items/b4afdefd-4cd1-146a-e040-e00a180610a2",
+        "http://digitalcollections.nypl.org/items/bc3bede1-86a7-cebb-e040-e00a18064596"
+    ],
+    "🚧": [],
+    "🚨": [],
+    "🚩": [
+        "http://digitalcollections.nypl.org/items/510d47da-d10a-a3d9-e040-e00a18064a99"
+    ],
+    "🚪": [
+        "http://digitalcollections.nypl.org/items/af816b78-c7c5-c09e-e040-e00a18062945",
+        "http://digitalcollections.nypl.org/items/aea7cced-6f65-982c-e040-e00a1806318e",
+        "http://digitalcollections.nypl.org/items/aea7cced-6f14-982c-e040-e00a1806318e",
+        "http://digitalcollections.nypl.org/items/aea7cced-6f29-982c-e040-e00a1806318e",
+        "http://digitalcollections.nypl.org/items/aea7cced-7137-982c-e040-e00a1806318e"
+    ],
+    "🚫": [],
+    "🚬": [
+        "http://digitalcollections.nypl.org/items/b48cc5d3-f26c-175e-e040-e00a180651cd",
+        "http://digitalcollections.nypl.org/items/5dd7ac50-e052-0131-d0e0-58d385a7b928"
+    ],
+    "🚭": [
+        "http://digitalcollections.nypl.org/items/510d47e3-7831-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-435c-a3d9-e040-e00a18064a99"
+    ],
+    "🚮": [
+        "http://digitalcollections.nypl.org/items/b153a2d9-9cc2-2146-e040-e00a18062823"
+    ],
+    "🚯": [
+        "http://digitalcollections.nypl.org/items/b4afdefd-4c53-146a-e040-e00a180610a2"
+    ],
+    "🚰": [
+        "http://digitalcollections.nypl.org/items/ae7bb9f5-4548-5a5d-e040-e00a1806317f"
+    ],
+    "🚱": [
+        "http://digitalcollections.nypl.org/items/af9c1ab0-e906-0131-1c10-3c075448cc4b"
+    ],
+    "🚲": [
+        "http://digitalcollections.nypl.org/items/510d47de-4b8d-a3d9-e040-e00a18064a99"
+    ],
+    "🚳": [],
+    "🚴": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-77dc-d471-e040-e00a180654d7"
+    ],
+    "🚵": [
+        "http://digitalcollections.nypl.org/items/510d47da-cf66-a3d9-e040-e00a18064a99"
+    ],
+    "🚶": [
+        "http://digitalcollections.nypl.org/items/4627eee0-ea71-0131-5384-58d385a7bbd0"
+    ],
+    "🚷": [],
+    "🚸": [],
+    "🚹": [],
+    "🚺": [
+        "http://digitalcollections.nypl.org/items/510d47e0-fe3b-a3d9-e040-e00a18064a99"
+    ],
+    "🚻": [],
+    "🚼": [
+        "http://digitalcollections.nypl.org/items/510d47d9-3cd1-a3d9-e040-e00a18064a99"
+    ],
+    "🚽": [
+        "http://digitalcollections.nypl.org/items/b4afdefd-4bd7-146a-e040-e00a180610a2"
+    ],
+    "🚾": [
+        "http://digitalcollections.nypl.org/items/510d47db-cd91-a3d9-e040-e00a18064a99"
+    ],
+    "🚿": [
+        "http://digitalcollections.nypl.org/items/510d47dc-45d8-a3d9-e040-e00a18064a99"
+    ],
+    "🛀": [
+        "http://digitalcollections.nypl.org/items/510d47dc-4634-a3d9-e040-e00a18064a99"
+    ],
+    "🛁": [
+        "http://digitalcollections.nypl.org/items/510d47db-ccf3-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47db-cccf-a3d9-e040-e00a18064a99"
+    ],
+    "🛂": [],
+    "🛃": [
+        "http://digitalcollections.nypl.org/items/510d47d9-974f-a3d9-e040-e00a18064a99"
+    ],
+    "🛄": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b7b5-a3d9-e040-e00a18064a99"
+    ],
+    "🛅": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-9a8e-d471-e040-e00a180654d7"
+    ],
+    "🛋": [
+        "http://digitalcollections.nypl.org/items/510d47e2-cb71-a3d9-e040-e00a18064a99"
+    ],
+    "🛌": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-ae05-d471-e040-e00a180654d7"
+    ],
+    "🛍": [
+        "http://digitalcollections.nypl.org/items/510d47dd-9ed4-a3d9-e040-e00a18064a99"
+    ],
+    "🛎": [
+        "http://digitalcollections.nypl.org/items/b0ead0eb-6644-29dc-e040-e00a18060c48",
+        "http://digitalcollections.nypl.org/items/510d47e3-f7da-a3d9-e040-e00a18064a99"
+    ],
+    "🛏": [
+        "http://digitalcollections.nypl.org/items/510d47e4-19db-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-cb91-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/b4afdefd-4917-146a-e040-e00a180610a2"
+    ],
+    "🛐": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-84db-d471-e040-e00a180654d7"
+    ],
+    "🛠": [
+        "http://digitalcollections.nypl.org/items/510d47d9-acbf-a3d9-e040-e00a18064a99"
+    ],
+    "🛡": [
+        "http://digitalcollections.nypl.org/items/510d47da-5426-a3d9-e040-e00a18064a99"
+    ],
+    "🛢": [
+        "http://digitalcollections.nypl.org/items/510d47d9-b645-a3d9-e040-e00a18064a99"
+    ],
+    "🛣": [
+        "http://digitalcollections.nypl.org/items/510d47d9-9dcb-a3d9-e040-e00a18064a99"
+    ],
+    "🛤": [
+        "http://digitalcollections.nypl.org/items/510d47e1-8b78-a3d9-e040-e00a18064a99"
+    ],
+    "🛥": [
+        "http://digitalcollections.nypl.org/items/510d47d9-bac2-a3d9-e040-e00a18064a99"
+    ],
+    "🛩": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-897b-d471-e040-e00a180654d7"
+    ],
+    "🛫": [
+        "http://digitalcollections.nypl.org/items/510d47e2-279e-a3d9-e040-e00a18064a99"
+    ],
+    "🛬": [
+        "http://digitalcollections.nypl.org/items/78309df1-1093-23cc-e040-e00a180647e6"
+    ],
+    "🛰": [
+        "http://digitalcollections.nypl.org/items/5e66b3e8-fc6a-d471-e040-e00a180654d7"
+    ],
+    "🛳": [
+        "http://digitalcollections.nypl.org/items/510d47db-7e75-a3d9-e040-e00a18064a99"
+    ],
+    "🤐": [],
+    "🤑": [],
+    "🤒": [],
+    "🤓": [
+        "http://digitalcollections.nypl.org/items/ba309cea-95e2-4288-e040-e00a18066c61"
+    ],
+    "🤔": [
+        "http://digitalcollections.nypl.org/items/b16926af-3eff-6b2f-e040-e00a1806531a",
+        "http://digitalcollections.nypl.org/items/510d47db-e00b-a3d9-e040-e00a18064a99"
+    ],
+    "🤕": [
+        "http://digitalcollections.nypl.org/items/510d47e3-0218-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e3-001c-a3d9-e040-e00a18064a99"
+    ],
+    "🤖": [
         "http://digitalcollections.nypl.org/items/510d47dd-fc66-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47da-93ab-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/5e66b3e8-7baf-d471-e040-e00a180654d7",
@@ -2465,846 +3216,44 @@
         "http://digitalcollections.nypl.org/items/5e66b3e8-f10f-d471-e040-e00a180654d7",
         "http://digitalcollections.nypl.org/items/5e66b3e8-e548-d471-e040-e00a180654d7"
     ],
-    "rocket":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-05fc-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47df-4539-a3d9-e040-e00a18064a99"
+    "🤗": [
+        "http://digitalcollections.nypl.org/items/5e66b3e9-20ff-d471-e040-e00a180654d7"
     ],
-    "rolled_up_newspaper": [],
-    "roller_coaster":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-1664-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47d9-cc19-a3d9-e040-e00a18064a99"
-    ],
-    "rooster":[
-        "http://digitalcollections.nypl.org/items/a4958095-4644-074d-e040-e00a1806792c",
-        "http://digitalcollections.nypl.org/items/510d47e3-7872-a3d9-e040-e00a18064a99"
-    ],
-    "rose":[
-        "http://digitalcollections.nypl.org/items/510d47da-ce9c-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-4175-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-65be-a3d9-e040-e00a18064a99"
-    ],
-    "rosette":[
-        "http://digitalcollections.nypl.org/items/510d47e1-1620-a3d9-e040-e00a18064a99"
-    ],
-    "rotating_light": [],
-    "round_pushpin": [],
-    "rowboat":[
-        "http://digitalcollections.nypl.org/items/510d47d9-b9a3-a3d9-e040-e00a18064a99"
-    ],
-    "ru": [],
-    "rugby_football":[
-        "http://digitalcollections.nypl.org/items/510d47da-792d-a3d9-e040-e00a18064a99"
-    ],
-    "runner":[
-        "http://digitalcollections.nypl.org/items/510d47de-7674-a3d9-e040-e00a18064a99"
-    ],
-    "running": [],
-    "running_shirt_with_sash":[
-        "http://digitalcollections.nypl.org/items/510d47dc-48d0-a3d9-e040-e00a18064a99"
-    ],
-    "sa": [],
-    "sagittarius":[
-        "http://digitalcollections.nypl.org/items/510d47e4-677d-a3d9-e040-e00a18064a99"
-    ],
-    "sailboat": [],
-    "sake":[
-        "http://digitalcollections.nypl.org/items/510d47d9-83a9-a3d9-e040-e00a18064a99"
-    ],
-    "sandal":[
-        "http://digitalcollections.nypl.org/items/510d47da-6eae-a3d9-e040-e00a18064a99"
-    ],
-    "santa":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6f94-a3d9-e040-e00a18064a99"
-    ],
-    "satellite":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-fc6a-d471-e040-e00a180654d7"
-    ],
-    "satisfied": [],
-    "saxophone":[
-        "http://digitalcollections.nypl.org/items/8be85efd-01c9-2a4b-e040-e00a18065153",
-        "http://digitalcollections.nypl.org/items/6284748f-2316-3fb4-e040-e00a180647d6"
-    ],
-    "scales":[
-        "http://digitalcollections.nypl.org/items/510d47dd-d3af-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/191f18f0-1696-0132-8346-58d385a7b928"
-    ],
-    "school": [
-        "http://digitalcollections.nypl.org/items/510d47e0-61b2-a3d9-e040-e00a18064a99"
-    ],
-    "school_satchel":[
-        "http://digitalcollections.nypl.org/items/510d47e0-e282-a3d9-e040-e00a18064a99"
-    ],
-    "scissors":[
-        "http://digitalcollections.nypl.org/items/510d47d9-acc2-a3d9-e040-e00a18064a99"
-    ],
-    "scorpion":[
-        "http://digitalcollections.nypl.org/items/510d47d9-52e1-a3d9-e040-e00a18064a99"
-    ],
-    "scorpius":[
-        "http://digitalcollections.nypl.org/items/510d47e4-6779-a3d9-e040-e00a18064a99"
-    ],
-    "scream":[
-        "http://digitalcollections.nypl.org/items/510d47e1-375b-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/8bfbd237-2d0f-aed1-e040-e00a1806680b"
-    ],
-    "scream_cat":[
-        "http://digitalcollections.nypl.org/items/510d47da-9b69-a3d9-e040-e00a18064a99"
-    ],
-    "scroll":[
-        "http://digitalcollections.nypl.org/items/510d47e1-d75b-a3d9-e040-e00a18064a99"
-    ],
-    "seat":[
-        "http://digitalcollections.nypl.org/items/510d47e2-e1b9-a3d9-e040-e00a18064a99"
-    ],
-    "secret": [],
-    "see_no_evil":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c693-a3d9-e040-e00a18064a99"
-    ],
-    "seedling":[
-        "http://digitalcollections.nypl.org/items/510d47e3-c056-a3d9-e040-e00a18064a99"
-    ],
-    "seven": [],
-    "shamrock":[
-        "http://digitalcollections.nypl.org/items/510d47da-ce9e-a3d9-e040-e00a18064a99"
-    ],
-    "shaved_ice":[
-        "http://digitalcollections.nypl.org/items/7b07ea5c-622b-6b59-e040-e00a18065a4d"
-    ],
-    "sheep":[
-        "http://digitalcollections.nypl.org/items/510d47e0-cf58-a3d9-e040-e00a18064a99"
-    ],
-    "shell":[
-        "http://digitalcollections.nypl.org/items/510d47db-b63a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-cc13-a3d9-e040-e00a18064a99"
-    ],
-    "shield":[
-        "http://digitalcollections.nypl.org/items/510d47da-5426-a3d9-e040-e00a18064a99"
-    ],
-    "shinto_shrine":[
-        "http://digitalcollections.nypl.org/items/c260bdb3-9b43-4552-e040-e00a18066d81",
-        "http://digitalcollections.nypl.org/items/c260bdb3-9b7c-4552-e040-e00a18066d81"
-    ],
-    "ship":[
-        "http://digitalcollections.nypl.org/items/510d47dd-fb8e-a3d9-e040-e00a18064a99"
-    ],
-    "shirt": [],
-    "shit": [],
-    "shoe": [],
-    "shopping_bags":[
-        "http://digitalcollections.nypl.org/items/510d47dd-9ed4-a3d9-e040-e00a18064a99"
-    ],
-    "shower":[
-        "http://digitalcollections.nypl.org/items/510d47dc-45d8-a3d9-e040-e00a18064a99"
-    ],
-    "showman":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c451-d471-e040-e00a180654d7"
-    ],
-    "sign_of_the_horns": [],
-    "signal_strength":[
-        "http://digitalcollections.nypl.org/items/9413e341-32e4-7c92-e040-e00a18064d91"
-    ],
-    "six": [],
-    "six_pointed_star": [
-        "http://digitalcollections.nypl.org/items/510d47dc-4037-a3d9-e040-e00a18064a99"    
-    ],
-    "ski":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e288-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-070f-d471-e040-e00a180654d7"
-    ],
-    "skier":[
-        "http://digitalcollections.nypl.org/items/510d47da-7947-a3d9-e040-e00a18064a99"
-    ],
-    "skin-tone-2": [],
-    "skin-tone-3": [],
-    "skin-tone-4": [],
-    "skin-tone-5": [],
-    "skin-tone-6": [],
-    "skull":[
-        "http://digitalcollections.nypl.org/items/74c9f570-82b9-0130-400f-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/6956ae61-c1d4-3815-e040-e00a18065ecc",
-        "http://digitalcollections.nypl.org/items/510d47db-3865-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-dd3d-d471-e040-e00a180654d7"
-    ],
-    "skull_and_crossbones": [
-        "http://digitalcollections.nypl.org/items/510d47db-122b-a3d9-e040-e00a18064a99"
-    ],
-    "sleeping":[
-        "http://digitalcollections.nypl.org/items/510d47e3-3e49-a3d9-e040-e00a18064a99"
-    ],
-    "sleeping_accommodation":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ae05-d471-e040-e00a180654d7"
-    ],
-    "sleepy":[
-        "http://digitalcollections.nypl.org/items/9152d417-7eae-9ea8-e040-e00a18064db0",
-        "http://digitalcollections.nypl.org/items/510d47e1-19ef-a3d9-e040-e00a18064a99"
-    ],
-    "sleuth_or_spy":[
-        "http://digitalcollections.nypl.org/items/510d47e1-2316-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-b975-a3d9-e040-e00a18064a99"
-    ],
-    "slightly_frowning_face": [
-        "http://digitalcollections.nypl.org/items/510d47e1-43c1-a3d9-e040-e00a18064a99"
-    ],
-    "slightly_smiling_face": [
-        "http://digitalcollections.nypl.org/items/d9a432d0-e04a-0131-8623-58d385a7bbd0"
-    ],
-    "slot_machine": [],
-    "small_airplane": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-897b-d471-e040-e00a180654d7"
-    ],
-    "small_blue_diamond": [],
-    "small_orange_diamond": [],
-    "small_red_triangle": [],
-    "small_red_triangle_down": [],
-    "smile":[
-        "http://digitalcollections.nypl.org/items/510d47e0-ed58-a3d9-e040-e00a18064a99"
-    ],
-    "smile_cat":[
-        "http://digitalcollections.nypl.org/items/510d47dd-f4ac-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-8f35-a3d9-e040-e00a18064a99"
-    ],
-    "smiley": [],
-    "smiley_cat":[
-        "http://digitalcollections.nypl.org/items/33a1aae0-e04c-0131-00cf-58d385a7bbd0"
-    ],
-    "smiling_imp":[
-        "http://digitalcollections.nypl.org/items/3547ff80-82b8-0130-ac49-58d385a7bbd0"
-    ],
-    "smirk":[
-        "http://digitalcollections.nypl.org/items/70833100-aafa-0132-1ad3-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-244e-d471-e040-e00a180654d7"
-    ],
-    "smirk_cat":[
-        "http://digitalcollections.nypl.org/items/510d47e1-43b5-a3d9-e040-e00a18064a99"
-    ],
-    "smoking":[
-        "http://digitalcollections.nypl.org/items/b48cc5d3-f26c-175e-e040-e00a180651cd",
-        "http://digitalcollections.nypl.org/items/5dd7ac50-e052-0131-d0e0-58d385a7b928"
-    ],
-    "snail":[
-        "http://digitalcollections.nypl.org/items/510d47e3-c0e8-a3d9-e040-e00a18064a99"
-    ],
-    "snake":[
-        "http://digitalcollections.nypl.org/items/510d47e1-1e18-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e9-13a2-d471-e040-e00a180654d7"
-    ],
-    "snow_capped_mountain":[
-        "http://digitalcollections.nypl.org/items/510d47d9-9bdb-a3d9-e040-e00a18064a99"
-    ],
-    "snow_cloud":[
-        "http://digitalcollections.nypl.org/items/510d47e1-946c-a3d9-e040-e00a18064a99"
-    ],
-    "snowboarder": [],
-    "snowflake":[
-        "http://digitalcollections.nypl.org/items/510d47e3-9ac2-a3d9-e040-e00a18064a99"
-    ],
-    "snowman":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c451-d471-e040-e00a180654d7"
-    ],
-    "sob":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c153-d471-e040-e00a180654d7"
-    ],
-    "soccer":[
-        "http://digitalcollections.nypl.org/items/510d47da-682c-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47df-a745-a3d9-e040-e00a18064a99"
-    ],
-    "soon": [],
-    "sos": [],
-    "sound": [],
-    "space_invader":[
-        "http://digitalcollections.nypl.org/items/510d47de-3b05-a3d9-e040-e00a18064a99"
-    ],
-    "spades":[
-        "http://digitalcollections.nypl.org/items/510d47e3-2541-a3d9-e040-e00a18064a99"
-    ],
-    "spaghetti":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-f2ef-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-598e-f55a-e040-e00a18062565"
-    ],
-    "sparkle": [],
-    "sparkler":[
-        "http://digitalcollections.nypl.org/items/510d47e3-4763-a3d9-e040-e00a18064a99"
-    ],
-    "sparkles":[
-        "http://digitalcollections.nypl.org/items/893c0fe7-81f4-ad5f-e040-e00a18064278"
-    ],
-    "sparkling_heart":[
-        "http://digitalcollections.nypl.org/items/510d47dd-e567-a3d9-e040-e00a18064a99"
-    ],
-    "speak_no_evil":[
-        "http://digitalcollections.nypl.org/items/510d47d9-c695-a3d9-e040-e00a18064a99"
-    ],
-    "speaker": [],
-    "speaking_head_in_silhouette":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-768c-d471-e040-e00a180654d7"
-    ],
-    "speech_balloon": [],
-    "speedboat":[
-        "http://digitalcollections.nypl.org/items/510d47de-76bc-a3d9-e040-e00a18064a99"
-    ],
-    "spider":[
-        "http://digitalcollections.nypl.org/items/510d47e1-087b-a3d9-e040-e00a18064a99"
-    ],
-    "spider_web":[
-        "http://digitalcollections.nypl.org/items/510d47e1-0888-a3d9-e040-e00a18064a99"
-    ],
-    "spiral_calendar_pad":[
-        "http://digitalcollections.nypl.org/items/510d47e3-afbc-a3d9-e040-e00a18064a99"
-    ],
-    "spiral_note_pad":[
-        "http://digitalcollections.nypl.org/items/28ba45d0-ba67-0130-4c75-58d385a7b928"
-    ],
-    "spock-hand":[
-        "http://digitalcollections.nypl.org/items/152d9370-9f4d-0132-f97d-58d385a7bbd0"
-    ],
-    "sports_medal": [],
-    "stadium":[
-        "http://digitalcollections.nypl.org/items/510d47e4-58c2-a3d9-e040-e00a18064a99"
-    ],
-    "star": [],
-    "star2":[
-        "http://digitalcollections.nypl.org/items/510d47e3-2b9a-a3d9-e040-e00a18064a99"
-    ],
-    "star_and_crescent": [],
-    "star_of_david": [],
-    "stars":[
-        "http://digitalcollections.nypl.org/items/510d47e2-49ad-a3d9-e040-e00a18064a99"
-    ],
-    "station":[
-        "http://digitalcollections.nypl.org/items/510d47e4-8418-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/9154e0ad-1c25-6f41-e040-e00a180667ae"
-    ],
-    "statue_of_liberty":[
-        "http://digitalcollections.nypl.org/items/510d47de-0a2c-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/0328dfd0-c254-0130-6535-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/510d47e4-6636-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47de-0a2d-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-8e33-a3d9-e040-e00a18064a99"
-    ],
-    "steam_locomotive":[
-        "http://digitalcollections.nypl.org/items/510d47e3-617c-a3d9-e040-e00a18064a99"
-    ],
-    "stew":[
-        "http://digitalcollections.nypl.org/items/afbf98ff-4766-7e08-e040-e00a18064829"
-    ],
-    "stopwatch":[
-        "http://digitalcollections.nypl.org/items/510d47dc-99f2-a3d9-e040-e00a18064a99"
-    ],
-    "straight_ruler":[
-        "http://digitalcollections.nypl.org/items/510d47df-f9f7-a3d9-e040-e00a18064a99"
-    ],
-    "strawberry":[
-        "http://digitalcollections.nypl.org/items/510d47da-93b9-a3d9-e040-e00a18064a99"
-    ],
-    "stuck_out_tongue":[
-        "http://digitalcollections.nypl.org/items/510d47e2-c6d1-a3d9-e040-e00a18064a99"
-    ],
-    "stuck_out_tongue_closed_eyes":[
-        "http://digitalcollections.nypl.org/items/510d47dd-f278-a3d9-e040-e00a18064a99"
-    ],
-    "stuck_out_tongue_winking_eye": [
-        "http://digitalcollections.nypl.org/items/510d47e3-64ab-a3d9-e040-e00a18064a99"
-    ],
-    "studio_microphone":[
-        "http://digitalcollections.nypl.org/items/9e78418c-529f-94eb-e040-e00a180656ef",
-        "http://digitalcollections.nypl.org/items/7b8172c8-b46c-d1a9-e040-e00a1806198a"
-    ],
-    "sun_behind_cloud": [],
-    "sun_behind_rain_cloud": [],
-    "sun_small_cloud": [],
-    "sun_with_face":[
-        "http://digitalcollections.nypl.org/items/a2dce264-6010-361b-e040-e00a18060eae",
-        "http://digitalcollections.nypl.org/items/510d47e1-165a-a3d9-e040-e00a18064a99"
-    ],
-    "sunflower":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6618-a3d9-e040-e00a18064a99"
-    ],
-    "sunglasses":[
-        "http://digitalcollections.nypl.org/items/081422c0-2289-0132-7f45-58d385a7bbd0",
-        "http://digitalcollections.nypl.org/items/8af99501-836d-161c-e040-e00a18064530"
-    ],
-    "sunny":[
-        "http://digitalcollections.nypl.org/items/510d47e2-1d68-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-c0c6-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47da-d112-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-e81f-a3d9-e040-e00a18064a99"
-    ],
-    "sunrise":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a185-a3d9-e040-e00a18064a99"
-    ],
-    "sunrise_over_mountains":[
-        "http://digitalcollections.nypl.org/items/510d47d9-a35a-a3d9-e040-e00a18064a99"
-    ],
-    "surfer":[
-        "http://digitalcollections.nypl.org/items/510d47e3-dc4c-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/a29dbeab-a2f8-6c08-e040-e00a18063abd"
-    ],
-    "sushi":[
-        "http://digitalcollections.nypl.org/items/d31499a0-3f63-0131-276a-58d385a7bbd0"
-    ],
-    "suspension_railway": [],
-    "sweat":[
-        "http://digitalcollections.nypl.org/items/6762c9d0-93fd-0130-ee5a-58d385a7b928"
-    ],
-    "sweat_drops":[
-        "http://digitalcollections.nypl.org/items/8bfbd237-2d13-aed1-e040-e00a1806680b"
-    ],
-    "sweat_smile":[
-        "http://digitalcollections.nypl.org/items/d1c0bf40-2d4c-0132-e5bd-58d385a7b928"
-    ],
-    "sweet_potato":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ced9-d471-e040-e00a180654d7"
-    ],
-    "swimmer":[
-        "http://digitalcollections.nypl.org/items/510d47e4-68fa-a3d9-e040-e00a18064a99"
-    ],
-    "symbols": [],
-    "synagogue":[
-        "http://digitalcollections.nypl.org/items/510d47e0-1efa-a3d9-e040-e00a18064a99"
-    ],
-    "syringe":[
-        "http://digitalcollections.nypl.org/items/510d47e3-62ab-a3d9-e040-e00a18064a99"
-    ],
-    "table_tennis_paddle_and_ball":[
-        "http://digitalcollections.nypl.org/items/7d20cdeb-e421-4a73-e040-e00a18060ccc",
-        "http://digitalcollections.nypl.org/items/510d47e4-4201-a3d9-e040-e00a18064a99"
-    ],
-    "taco": [
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-57c6-f55a-e040-e00a18062565"    
-    ],
-    "tada":[
-        "http://digitalcollections.nypl.org/items/510d47da-4a5b-a3d9-e040-e00a18064a99"
-    ],
-    "tanabata_tree": [],
-    "tangerine":[
-        "http://digitalcollections.nypl.org/items/510d47dc-93c6-a3d9-e040-e00a18064a99"
-    ],
-    "taurus":[
-        "http://digitalcollections.nypl.org/items/510d47e4-703d-a3d9-e040-e00a18064a99"
-    ],
-    "taxi":[
-        "http://digitalcollections.nypl.org/items/b06e6ba0-8a28-0132-fba5-58d385a7bbd0"
-    ],
-    "tea":[
-        "http://digitalcollections.nypl.org/items/510d47dc-3eea-a3d9-e040-e00a18064a99"
-    ],
-    "telephone": [
-        "http://digitalcollections.nypl.org/items/510d47d9-b17d-a3d9-e040-e00a18064a99"
-    ],
-    "telephone_receiver":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ee59-d471-e040-e00a180654d7"
-    ],
-    "telescope":[
-        "http://digitalcollections.nypl.org/items/892929d8-2b6f-cc7d-e040-e00a18063fb3"
-    ],
-    "tennis":[
-        "http://digitalcollections.nypl.org/items/782f625e-0539-87c4-e040-e00a18061872"
-    ],
-    "tent":[
-        "http://digitalcollections.nypl.org/items/510d47da-cff3-a3d9-e040-e00a18064a99"
-    ],
-    "the_horns":[
+    "🤘": [
         "http://digitalcollections.nypl.org/items/510d47e1-439a-a3d9-e040-e00a18064a99"
     ],
-    "thermometer":[
-        "http://digitalcollections.nypl.org/items/510d47dd-f3bf-a3d9-e040-e00a18064a99"
+    "🦀": [
+        "http://digitalcollections.nypl.org/items/510d47e4-0fd6-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e4-0fe3-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/ac4b45d0-f810-0132-883f-58d385a7bbd0",
+        "http://digitalcollections.nypl.org/items/510d47da-66de-a3d9-e040-e00a18064a99"
     ],
-    "thinking_face":[
-        "http://digitalcollections.nypl.org/items/b16926af-3eff-6b2f-e040-e00a1806531a",
-        "http://digitalcollections.nypl.org/items/510d47db-e00b-a3d9-e040-e00a18064a99"
+    "🦁": [
+        "http://digitalcollections.nypl.org/items/510d47da-9eed-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47e2-24ea-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/7cfd6b6c-0e7f-8833-e040-e00a18067633",
+        "http://digitalcollections.nypl.org/items/78315148-f07f-8a8d-e040-e00a18064798",
+        "http://digitalcollections.nypl.org/items/91950f24-c3d9-a7e0-e040-e00a18062992",
+        "http://digitalcollections.nypl.org/items/510d47da-3e49-a3d9-e040-e00a18064a99"
     ],
-    "thought_balloon":[
-        "http://digitalcollections.nypl.org/items/510d47de-862e-a3d9-e040-e00a18064a99"
+    "🦂": [
+        "http://digitalcollections.nypl.org/items/510d47d9-52e1-a3d9-e040-e00a18064a99"
     ],
-    "three": [],
-    "three_button_mouse": [],
-    "thunder_cloud_and_rain": [],
-    "ticket":[
-        "http://digitalcollections.nypl.org/items/510d47df-75f2-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-c99d-d471-e040-e00a180654d7"
-    ],
-    "tiger":[
-        "http://digitalcollections.nypl.org/items/7cfd6b6c-0e69-8833-e040-e00a18067633"
-    ],
-    "tiger2":[
-        "http://digitalcollections.nypl.org/items/510d47e0-cfcb-a3d9-e040-e00a18064a99"
-    ],
-    "timer_clock": [],
-    "tired_face": [
-        "http://digitalcollections.nypl.org/items/90f27b23-76af-2d20-e040-e00a18064b4d"    
-    ],
-    "tm": [],
-    "toilet":[
-        "http://digitalcollections.nypl.org/items/b4afdefd-4bd7-146a-e040-e00a180610a2"
-    ],
-    "tokyo_tower": [
-        "http://digitalcollections.nypl.org/items/6afd4e50-f3da-0130-6b32-58d385a7bbd0"    
-    ],
-    "tomato":[
-        "http://digitalcollections.nypl.org/items/510d47dd-c6b1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/ae6c1dd9-5859-f55a-e040-e00a18062565"
-    ],
-    "tongue":[
-        "http://digitalcollections.nypl.org/items/510d47e4-593c-a3d9-e040-e00a18064a99"
-    ],
-    "top": [],
-    "tophat":[
-        "http://digitalcollections.nypl.org/items/510d47e1-22ac-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/498edbb0-1f93-0134-eeac-00505686a51c",
-        "http://digitalcollections.nypl.org/items/510d47e1-221b-a3d9-e040-e00a18064a99"
-    ],
-    "tornado":[
-        "http://digitalcollections.nypl.org/items/510d47d9-aa8a-a3d9-e040-e00a18064a99"
-    ],
-    "tornado_cloud": [
-        "http://digitalcollections.nypl.org/items/510d47d9-aa8a-a3d9-e040-e00a18064a99"
-    ],
-    "trackball": [],
-    "tractor":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-8dc5-d471-e040-e00a180654d7"
-    ],
-    "traffic_light": [],
-    "train": [],
-    "train2":[
-        "http://digitalcollections.nypl.org/items/5e66b3e9-06b9-d471-e040-e00a180654d7"
-    ],
-    "tram":[
-        "http://digitalcollections.nypl.org/items/510d47e2-478a-a3d9-e040-e00a18064a99"
-    ],
-    "triangular_flag_on_post":[
-        "http://digitalcollections.nypl.org/items/510d47da-d10a-a3d9-e040-e00a18064a99"
-    ],
-    "triangular_ruler":[
-        "http://digitalcollections.nypl.org/items/510d47df-fa20-a3d9-e040-e00a18064a99"
-    ],
-    "trident":[
-        "http://digitalcollections.nypl.org/items/574b0ec0-a3a9-0130-fa2b-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/5b487340-1d8a-0131-fdbd-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/510d47da-edbc-a3d9-e040-e00a18064a99"
-    ],
-    "triumph": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ddad-d471-e040-e00a180654d7"
-    ],
-    "trolleybus":[
-        "http://digitalcollections.nypl.org/items/510d47db-b897-a3d9-e040-e00a18064a99"
-    ],
-    "trophy":[
-        "http://digitalcollections.nypl.org/items/510d47de-058b-a3d9-e040-e00a18064a99"
-    ],
-    "tropical_drink":[
-        "http://digitalcollections.nypl.org/items/a4d03826-f1e0-a5c7-e040-e00a18066166",
-        "http://digitalcollections.nypl.org/items/af1f02d7-5606-ce42-e040-e00a18064e03"
-    ],
-    "tropical_fish":[
-        "http://digitalcollections.nypl.org/items/7d20c47c-2404-d7f9-e040-e00a18060c58"
-    ],
-    "truck":[
-        "http://digitalcollections.nypl.org/items/510d47db-b77e-a3d9-e040-e00a18064a99"
-    ],
-    "trumpet":[
-        "http://digitalcollections.nypl.org/items/6284748f-2319-3fb4-e040-e00a180647d6"
-    ],
-    "tshirt": [
-        "http://digitalcollections.nypl.org/items/c17b57e0-2b34-0134-7850-00505686a51c",
-        "http://digitalcollections.nypl.org/items/510d47e1-1e78-a3d9-e040-e00a18064a99"
-    ],
-    "tulip":[
-        "http://digitalcollections.nypl.org/items/510d47dd-ee52-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47dd-f17a-a3d9-e040-e00a18064a99"
-    ],
-    "turkey":[
+    "🦃": [
         "http://digitalcollections.nypl.org/items/510d47e3-52da-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47db-81d5-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/510d47e3-6473-a3d9-e040-e00a18064a99"
     ],
-    "turtle":[
-        "http://digitalcollections.nypl.org/items/510d47e1-08d7-a3d9-e040-e00a18064a99"
-    ],
-    "tv":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-95ad-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-9d7a-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/5e66b3e8-f864-d471-e040-e00a180654d7"
-    ],
-    "twisted_rightwards_arrows": [],
-    "two": [],
-    "two_hearts":[
-        "http://digitalcollections.nypl.org/items/510d47dd-b43d-a3d9-e040-e00a18064a99"
-    ],
-    "two_men_holding_hands":[
-        "http://digitalcollections.nypl.org/items/510d47e3-5788-a3d9-e040-e00a18064a99"
-    ],
-    "two_women_holding_hands":[
-        "http://digitalcollections.nypl.org/items/510d47e3-b6cf-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-9f90-a3d9-e040-e00a18064a99"
-    ],
-    "u5272": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u5408": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u55b6": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u6307": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u6708": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u6709": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u6e80": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u7121": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u7533": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u7981": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "u7a7a": [
-        "http://digitalcollections.nypl.org/items/510d47e3-9aa1-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/6d7dbfa8-458b-5754-e040-e00a18063ae0",
-        "http://digitalcollections.nypl.org/items/510d47dc-4818-a3d9-e040-e00a18064a99"
-    ],
-    "uk": [],
-    "umbrella":[
-        "http://digitalcollections.nypl.org/items/510d47e1-263a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e1-338d-a3d9-e040-e00a18064a99"
-    ],
-    "umbrella_on_ground":[
-        "http://digitalcollections.nypl.org/items/510d47df-f731-a3d9-e040-e00a18064a99"
-    ],
-    "unamused":[
-        "http://digitalcollections.nypl.org/items/510d47e1-784c-a3d9-e040-e00a18064a99"
-    ],
-    "underage": [
-        "http://digitalcollections.nypl.org/items/3f9ffdd0-08f0-0131-9724-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/9c91972e-ca67-25ad-e040-e00a18063ca7"
-    ],
-    "unicorn_face":[
+    "🦄": [
         "http://digitalcollections.nypl.org/items/510d47dd-cf09-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/5e66b3e8-b25b-d471-e040-e00a180654d7",
         "http://digitalcollections.nypl.org/items/510d47e1-4241-a3d9-e040-e00a18064a99",
         "http://digitalcollections.nypl.org/items/a5072ff0-25d7-0130-540b-58d385a7b928",
         "http://digitalcollections.nypl.org/items/510d47dc-8888-a3d9-e040-e00a18064a99"
     ],
-    "unlock": [],
-    "up": [],
-    "upside_down_face":[
-        "http://digitalcollections.nypl.org/items/8d6a1137-4bf6-1b84-e040-e00a1806585b",
-        "http://digitalcollections.nypl.org/items/8d9313d0-97f0-9154-e040-e00a1806770f"
-    ],
-    "us": [],
-    "v":[
-        "http://digitalcollections.nypl.org/items/510d47e3-af8f-a3d9-e040-e00a18064a99"
-    ],
-    "vertical_traffic_light":[
-        "http://digitalcollections.nypl.org/items/b4afdefd-4cd1-146a-e040-e00a180610a2",
-        "http://digitalcollections.nypl.org/items/bc3bede1-86a7-cebb-e040-e00a18064596"
-    ],
-    "vhs": [
-        "http://digitalcollections.nypl.org/items/9fa5d371-825d-7bd0-e040-e00a180606c8"    
-    ],
-    "vibration_mode": [],
-    "video_camera": [],
-    "video_game":[
-        "http://digitalcollections.nypl.org/items/510d47dc-ea03-a3d9-e040-e00a18064a99"
-    ],
-    "violin":[
-        "http://digitalcollections.nypl.org/items/510d47e2-df18-a3d9-e040-e00a18064a99"
-    ],
-    "virgo":[
-        "http://digitalcollections.nypl.org/items/510d47e4-6761-a3d9-e040-e00a18064a99"
-    ],
-    "volcano":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-d816-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47d9-83cd-a3d9-e040-e00a18064a99"
-    ],
-    "volleyball":[
-        "http://digitalcollections.nypl.org/items/510d47e0-db34-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47d9-bb8a-a3d9-e040-e00a18064a99"
-    ],
-    "vs": [
-        "http://digitalcollections.nypl.org/items/5e66b3e8-bcde-d471-e040-e00a180654d7"    
-    ],
-    "walking":[
-        "http://digitalcollections.nypl.org/items/4627eee0-ea71-0131-5384-58d385a7bbd0"
-    ],
-    "waning_crescent_moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
-    ],
-    "waning_gibbous_moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
-    ],
-    "warning": [],
-    "wastebasket":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-70af-d471-e040-e00a180654d7"
-    ],
-    "watch":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e288-d471-e040-e00a180654d7"
-    ],
-    "water_buffalo":[
-        "http://digitalcollections.nypl.org/items/4773e410-ff55-012f-5faa-58d385a7bc34"
-    ],
-    "watermelon":[
-        "http://digitalcollections.nypl.org/items/510d47db-5173-a3d9-e040-e00a18064a99"
-    ],
-    "wave":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-ac5a-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/477e5930-a0df-0132-2fb3-58d385a7b928",
-        "http://digitalcollections.nypl.org/items/510d47df-f9fb-a3d9-e040-e00a18064a99"
-    ],
-    "waving_black_flag":[
-        "http://digitalcollections.nypl.org/items/510d47e1-23e3-a3d9-e040-e00a18064a99"
-    ],
-    "waving_white_flag":[
-        "http://digitalcollections.nypl.org/items/510d47e0-f629-a3d9-e040-e00a18064a99"
-    ],
-    "wavy_dash":[
-        "http://digitalcollections.nypl.org/items/510d47da-9246-a3d9-e040-e00a18064a99"
-    ],
-    "waxing_crescent_moon":[
-        "http://digitalcollections.nypl.org/items/510d47da-d114-a3d9-e040-e00a18064a99"
-    ],
-    "waxing_gibbous_moon": [],
-    "wc":[
-        "http://digitalcollections.nypl.org/items/510d47db-cd91-a3d9-e040-e00a18064a99"
-    ],
-    "weary": [
-        "http://digitalcollections.nypl.org/items/510d47e2-f6f9-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e3-7853-a3d9-e040-e00a18064a99"
-    ],
-    "wedding":[
-        "http://digitalcollections.nypl.org/items/510d47e2-d1a7-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-d0ea-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-d0ef-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e2-d1a8-a3d9-e040-e00a18064a99"
-    ],
-    "weight_lifter":[
-        "http://digitalcollections.nypl.org/items/510d47dc-9c1c-a3d9-e040-e00a18064a99"
-    ],
-    "whale":[
-        "http://digitalcollections.nypl.org/items/510d47db-d768-a3d9-e040-e00a18064a99"
-    ],
-    "whale2":[
-        "http://digitalcollections.nypl.org/items/510d47e0-d034-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/8bbf1c8a-57a0-1c76-e040-e00a1806015b",
-        "http://digitalcollections.nypl.org/items/510d47db-d677-a3d9-e040-e00a18064a99"
-    ],
-    "wheel_of_dharma": [],
-    "wheelchair": [
-        "http://digitalcollections.nypl.org/items/510d47dc-48ad-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47db-d0d1-a3d9-e040-e00a18064a99"
-    ],
-    "white_check_mark": [],
-    "white_circle": [
-        "http://digitalcollections.nypl.org/items/5e66b3e9-2730-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47dc-4405-a3d9-e040-e00a18064a99"
-    ],
-    "white_flower":[
-        "http://digitalcollections.nypl.org/items/510d47e1-cae3-a3d9-e040-e00a18064a99"
-    ],
-    "white_frowning_face": [],
-    "white_large_square": [],
-    "white_medium_small_square": [],
-    "white_medium_square": [],
-    "white_small_square": [],
-    "white_square_button": [],
-    "wind_blowing_face":[
-        "http://digitalcollections.nypl.org/items/510d47e4-736a-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47e4-1d1c-a3d9-e040-e00a18064a99"
-    ],
-    "wind_chime": [
-        "http://digitalcollections.nypl.org/items/510d47e4-643b-a3d9-e040-e00a18064a99"
-    ],
-    "wine_glass":[
-        "http://digitalcollections.nypl.org/items/510d47e3-accc-a3d9-e040-e00a18064a99"
-    ],
-    "wink":[
-        "http://digitalcollections.nypl.org/items/0e56d120-6988-0130-fe6e-58d385a7b928"
-    ],
-    "wolf":[
-        "http://digitalcollections.nypl.org/items/510d47da-bc6f-a3d9-e040-e00a18064a99"
-    ],
-    "woman":[
-        "http://digitalcollections.nypl.org/items/510d47e2-f85f-a3d9-e040-e00a18064a99"
-    ],
-    "woman-heart-woman": [
-        "http://digitalcollections.nypl.org/items/510d47e3-8353-a3d9-e040-e00a18064a99"    
-    ],
-    "woman-kiss-woman": [
-        "http://digitalcollections.nypl.org/items/510d47e3-960e-a3d9-e040-e00a18064a99"    
-    ],
-    "woman-woman-boy": [],
-    "woman-woman-boy-boy": [],
-    "woman-woman-girl": [],
-    "woman-woman-girl-boy": [],
-    "woman-woman-girl-girl": [],
-    "womans_clothes":[
-        "http://digitalcollections.nypl.org/items/ed653680-a8d7-0132-2d6c-58d385a7b928"
-    ],
-    "womans_hat":[
-        "http://digitalcollections.nypl.org/items/510d47e1-2239-a3d9-e040-e00a18064a99"
-    ],
-    "womens":[
-        "http://digitalcollections.nypl.org/items/510d47e0-fe3b-a3d9-e040-e00a18064a99"
-    ],
-    "world_map":[
-        "http://digitalcollections.nypl.org/items/510d47e3-719e-a3d9-e040-e00a18064a99"
-    ],
-    "worried": [
-        "http://digitalcollections.nypl.org/items/6b27a1d9-1d61-b8da-e040-e00a18062c91"    
-    ],
-    "wrench":[
-        "http://digitalcollections.nypl.org/items/510d47e4-4a9e-a3d9-e040-e00a18064a99"
-    ],
-    "writing_hand":[
-        "http://digitalcollections.nypl.org/items/510d47db-d3dd-a3d9-e040-e00a18064a99",
-        "http://digitalcollections.nypl.org/items/510d47df-9f29-a3d9-e040-e00a18064a99"
-    ],
-    "x": [],
-    "yellow_heart":[
-        "http://digitalcollections.nypl.org/items/510d47e3-6170-a3d9-e040-e00a18064a99"
-    ],
-    "yen": [],
-    "yin_yang":[
-        "http://digitalcollections.nypl.org/items/510d47e1-0117-a3d9-e040-e00a18064a99"
-    ],
-    "yum":[
-        "http://digitalcollections.nypl.org/items/510d47e1-43c5-a3d9-e040-e00a18064a99"
-    ],
-    "zap":[
-        "http://digitalcollections.nypl.org/items/5e66b3e8-e1ed-d471-e040-e00a180654d7",
-        "http://digitalcollections.nypl.org/items/510d47da-d0d2-a3d9-e040-e00a18064a99"
-    ],
-    "zero": [],
-    "zipper_mouth_face": [],
-    "zzz":[
-        "http://digitalcollections.nypl.org/items/8bfbd237-2d18-aed1-e040-e00a1806680b"]
+    "🧀": [
+        "http://digitalcollections.nypl.org/items/510d47d9-4f62-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/510d47dd-9d99-a3d9-e040-e00a18064a99",
+        "http://digitalcollections.nypl.org/items/ba309cea-92f4-4288-e040-e00a18066c61"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -9,11 +9,10 @@
     "url": "https://github.com/lolibrarian/NYPL-Emoji-Bot"
   },
   "dependencies": {
-    "emoji-regex": "^6.0.0",
-    "node-emoji": "^1.3.1",
     "twit": "1.x",
     "ejs": "2.4.1",
-    "express": "4.13.3"
+    "express": "4.13.3",
+    "thenby": "^1.2.1"
   },
   "bugs": {
     "url": "https://github.com/lolibrarian/NYPL-Emoji-Bot/issues"

--- a/script/identify.js
+++ b/script/identify.js
@@ -2,7 +2,7 @@
 
 const Images = require('../src/images');
 
-let character = process.argv[2];
-let image = new Images().getFromText(character);
+let text = process.argv[2];
+let image = new Images().getFromText(text);
 
 console.log(image);

--- a/src/image.js
+++ b/src/image.js
@@ -1,17 +1,13 @@
 'use strict';
 
-const emoji = require('node-emoji');
-
 class Image {
-  constructor(emoji_name, url) {
-    this.emoji_name = emoji_name;
+  constructor(key, url) {
+    this.key = key;
     this.url = url;
   }
 
   toString() {
-    let character = emoji.get(this.emoji_name);
-
-    return `${character} ${this.url}`;
+    return `${this.key} ${this.url}`;
   }
 }
 

--- a/src/incomplete.js
+++ b/src/incomplete.js
@@ -1,16 +1,12 @@
 'use strict';
 
-const emoji = require('node-emoji');
-
 class Incomplete {
-  constructor(emoji_name) {
-    this.emoji_name = emoji_name;
+  constructor(key) {
+    this.key = key;
   }
 
   toString() {
-    let character = emoji.get(this.emoji_name);
-
-    return `${character} ¯\\_(ツ)_/¯ Try searching digitalcollections.nypl.org for that!`;
+    return `${this.key} ¯\\_(ツ)_/¯ Try searching digitalcollections.nypl.org for that!`;
   }
 }
 

--- a/test/image.js
+++ b/test/image.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const Image = require('../src/image');
 
 describe('Image', () => {
-  let image = new Image('scream', 'http://example.com');
+  let image = new Image('😱', 'http://example.com');
 
   describe('#toString()', () => {
     it('should return a message', () => {

--- a/test/tweet.js
+++ b/test/tweet.js
@@ -5,7 +5,7 @@ const Image = require('../src/image');
 const Tweet = require('../src/tweet');
 
 describe('Tweet', () => {
-  let image = new Image('scream', 'http://example.com');
+  let image = new Image('😱', 'http://example.com');
   let tweet = new Tweet(image);
 
   describe('#getStatus()', () => {


### PR DESCRIPTION
The existing code does a poor job of identifying emojis with surrogate pairs (ex. flags and families).

Now, instead of attempting to extract emoji characters from a Tweet, we "brute force" match against all records, trying long sequences (ex. family-woman-woman-boy) and complete records (i.e. more than 0 URLs) first.

The existing data also has duplicates caused by the original migration (ex. `+1` and `thumbsup`). The newly migrated data is keyed by the supported emoji characters themselves.
