### PR TITLE
No results for emoji without variation selector

### DIFF
--- a/src/images.js
+++ b/src/images.js
@@ -6,6 +6,8 @@ const Image = require('./image');
 const ImageIncomplete = require('./image_incomplete');
 const firstBy = require('thenby');
 
+const VARIATION_SELECTOR_MATCHER = /\uFE0F$/;
+
 class Images {
   constructor (records) {
     this.records = records || data;
@@ -23,6 +25,8 @@ class Images {
     let keys = getSortedKeys(this.records);
 
     let key = keys.find((key) => {
+      key = getBaseCodepoint(key);
+
       return text.indexOf(key) !== -1;
     });
 
@@ -65,6 +69,21 @@ function getSortedKeys(records) {
     firstBy((a, b) => { return b.length - a.length; })
     .thenBy((a, b) => { return records[b].length - records[a].length; })
   );
+}
+
+/**
+ * Get the base codepoint, without the VS16 variation selector
+ *
+ * When searching, matching against the base character casts a wider net than the full emoji. In some cases, on some
+ * platforms, they're visually identical.
+ *
+ * For more information, please see: https://en.wikipedia.org/wiki/Emoji#Emoji_versus_text_presentation
+ *
+ * @param  {String} character
+ * @return {String}
+ */
+function getBaseCodepoint(character) {
+  return character.replace(VARIATION_SELECTOR_MATCHER, '');
 }
 
 module.exports = Images;

--- a/test/images.js
+++ b/test/images.js
@@ -71,6 +71,36 @@ describe('Images', () => {
             assert.equal(image.toString(), 'http://example.com/+1');
           });
         });
+
+        describe('variation selector characters', () => {
+          let records = {
+            '\u26C4\uFE0F': [ 'http://example.com/' ]
+          };
+
+          let images = new Images(records);
+
+          describe('present in text', () => {
+            let text = '\u26C4\uFE0F';
+
+            it('should return a record', () => {
+              let image = images.getFromText('@some_bot ' + text);
+
+              assert.equal(image.getKey(), '⛄️');
+              assert.equal(image.toString(), 'http://example.com/');
+            });
+          });
+
+          describe('missing in text', () => {
+            let text = '\u26C4';
+
+            it('should return a record', () => {
+              let image = images.getFromText('@some_bot ' + text);
+
+              assert.equal(image.getKey(), '⛄️');
+              assert.equal(image.toString(), 'http://example.com/');
+            });
+          });
+        });
       });
 
       describe('record found, but incomplete', () => {


### PR DESCRIPTION
There are a few cases were a base emoji (with no [VS16 variation selector](https://en.wikipedia.org/wiki/Emoji#Emoji_versus_text_presentation)) returns no results.

For example:

``` shell
$ bin/identify ⛄
null

$ bin/identify ⚓
null

$ bin/identify ⛲
null
```

When searching, we should match against the base character to cast a wider net. In some cases, on some platforms, they're visually identical.
